### PR TITLE
feat: ปรับ auto-schedule ตามเวรจริง + Fairness Dashboard + จองเวร + Export Excel + ปรับหน้า Home

### DIFF
--- a/components/AutoSchedule/AutoSchedulePanel.jsx
+++ b/components/AutoSchedule/AutoSchedulePanel.jsx
@@ -45,20 +45,24 @@ const AutoSchedulePanel = ({ month, year, locationId, onScheduleGenerated }) => 
 
       // ตรวจสอบรูปแบบข้อมูลที่ได้รับ
       console.log("API Response:", result.data);
-      
-      // จัดการข้อมูลที่ได้รับจาก API
-      const scheduleData = result.data.schedule || result.data;
-      
-      setGeneratedSchedule(scheduleData);
+
+      // จัดเก็บเป็น object เดียวให้ตรงกับที่ส่วนแสดงผลใช้งาน
+      const data = result.data || {};
+      setGeneratedSchedule({
+        schedule: data.schedule || [],
+        violations: data.violations || data.summary?.constraintViolations || [],
+        staffStats: data.staffStats || {},
+        summary: data.summary || {},
+      });
       setShowPreview(true);
     } catch (error) {
       console.error("Error generating schedule:", error);
-      alert("เกิดข้อผิดพลาดในการสร้างตารางอัตโนมัติ");
+      alert("เกิดข้อผิดพลาดในการสร้างตารางอัตโนมัติ: " + (error?.response?.data?.details || error.message));
     }
   };
 
   const handleApplySchedule = async () => {
-    if (!generatedSchedule?.schedule) return;
+    if (!generatedSchedule?.schedule?.length) return;
 
     try {
       const result = await executeApply({
@@ -71,15 +75,16 @@ const AutoSchedulePanel = ({ month, year, locationId, onScheduleGenerated }) => 
         }
       });
 
-      alert(`บันทึกตารางเวรสำเร็จ!\nสร้างเวรใหม่: ${result.data.summary.created} เวร\nข้อผิดพลาด: ${result.data.summary.errors} รายการ`);
-      
+      const s = result.data?.summary || {};
+      alert(`บันทึกตารางเวรสำเร็จ!\nสร้าง/อัปเดต: ${s.created ?? 0} เวร\nลบของเดิม: ${s.deleted ?? 0} เวร\nข้อผิดพลาด: ${s.errors ?? 0} รายการ`);
+
       setGeneratedSchedule(null);
       setShowPreview(false);
       onScheduleGenerated && onScheduleGenerated();
-      
+
     } catch (error) {
       console.error("Error applying schedule:", error);
-      alert("เกิดข้อผิดพลาดในการบันทึกตารางเวร");
+      alert("เกิดข้อผิดพลาดในการบันทึกตารางเวร: " + (error?.response?.data?.details || error.message));
     }
   };
 
@@ -275,7 +280,7 @@ const AutoSchedulePanel = ({ month, year, locationId, onScheduleGenerated }) => 
                       ID: {userId.slice(-6)}
                     </div>
                     <div className="text-sm">
-                      <span className="font-medium">เวรทั้งหมด:</span> {stats.totalShifts} เวร
+                      <span className="font-medium">เวรทั้งหมด:</span> {stats.totalWorkload ?? 0} เวร
                     </div>
                     <div className="text-xs text-gray-600">
                       ช: {stats.shiftCounts.ช || 0} | บ: {stats.shiftCounts.บ || 0} | ด: {stats.shiftCounts.ด || 0}
@@ -299,7 +304,7 @@ const AutoSchedulePanel = ({ month, year, locationId, onScheduleGenerated }) => 
                 className="mr-2 w-4 h-4 text-blue-600"
               />
               <span className="text-sm">
-                แทนที่ตารางเวรที่มีอยู่ (จะลบเวรเดิมทั้งหมดในเดือนนี้)
+                แทนที่ตารางเวรที่มีอยู่ (จะลบเวรเดิมของแผนกนี้ในเดือนนี้ก่อนบันทึกใหม่)
               </span>
             </label>
           </div>

--- a/components/ExportExcelButton.jsx
+++ b/components/ExportExcelButton.jsx
@@ -1,0 +1,94 @@
+import useAxios from "axios-hooks";
+import * as XLSX from "xlsx";
+import dayjs from "dayjs";
+import "dayjs/locale/th";
+
+dayjs.locale("th");
+
+// ปุ่มส่งออกตารางเวรเป็นไฟล์ Excel (.xlsx) โดยดึงข้อมูลจากฐานข้อมูลโดยตรง
+const ExportExcelButton = ({ month, year }) => {
+  const [{ data, loading }] = useAxios({
+    url: `/api/user/selectMonth?month=${month}&year=${year}`,
+    method: "GET",
+  });
+
+  const monthTH = dayjs().month(month).format("MMMM");
+  const yearTH = year + 543;
+
+  const handleExport = () => {
+    const users = (data || []).filter((u) => u?.firstname);
+    if (users.length === 0) {
+      alert("ไม่มีข้อมูลเวรในเดือนนี้");
+      return;
+    }
+
+    const daysInMonth = dayjs().month(month).year(year).daysInMonth();
+
+    // หัวตาราง
+    const header = [
+      "ลำดับ",
+      "ชื่อ - สกุล",
+      "ตำแหน่ง",
+      ...Array.from({ length: daysInMonth }, (_, i) => i + 1),
+      "รวมเวร",
+      "OT",
+    ];
+
+    const rows = users.map((u, idx) => {
+      // รวมกะของแต่ละวัน (เวรควบ → ต่อกัน, OT → ใส่ * ต่อท้าย)
+      const cellByDay = {};
+      (u.Duty || []).forEach((d) => {
+        const day = dayjs(d.datetime).date();
+        const mark = (d.Shif?.name || "") + (d.isOT || d.Shif?.isOT ? "*" : "");
+        cellByDay[day] = (cellByDay[day] || "") + mark;
+      });
+
+      const work = (u.Duty || []).filter((d) =>
+        ["ช", "บ", "ด"].includes(d.Shif?.name)
+      ).length;
+      const ot = (u.Duty || []).filter((d) => d.isOT || d.Shif?.isOT).length;
+
+      return [
+        idx + 1,
+        `${u.Title?.name || ""}${u.firstname} ${u.lastname}`,
+        u.Position?.name || "",
+        ...Array.from({ length: daysInMonth }, (_, i) => cellByDay[i + 1] || ""),
+        work,
+        ot,
+      ];
+    });
+
+    const ws = XLSX.utils.aoa_to_sheet([
+      [`ตารางเวรประจำเดือน ${monthTH} พ.ศ. ${yearTH}`],
+      [],
+      header,
+      ...rows,
+    ]);
+
+    // กว้างคอลัมน์: ลำดับ/ชื่อ/ตำแหน่ง + วันที่แคบ
+    ws["!cols"] = [
+      { wch: 5 },
+      { wch: 22 },
+      { wch: 14 },
+      ...Array.from({ length: daysInMonth }, () => ({ wch: 4 })),
+      { wch: 7 },
+      { wch: 5 },
+    ];
+
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, `${monthTH} ${yearTH}`);
+    XLSX.writeFile(wb, `ตารางเวร_${monthTH}_${yearTH}.xlsx`);
+  };
+
+  return (
+    <button
+      onClick={handleExport}
+      disabled={loading}
+      className="px-4 py-2 text-white bg-emerald-600 rounded-md hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:opacity-50"
+    >
+      📊 ส่งออก Excel
+    </button>
+  );
+};
+
+export default ExportExcelButton;

--- a/components/Fairness/FairnessDashboard.jsx
+++ b/components/Fairness/FairnessDashboard.jsx
@@ -1,0 +1,193 @@
+import useAxios from "axios-hooks";
+import dayjs from "dayjs";
+import "dayjs/locale/th";
+import LoadingComponent from "../LoadingComponent";
+import ErrorComponent from "../ErrorComponent";
+
+dayjs.locale("th");
+
+const FairnessDashboard = ({ month, year }) => {
+  const [{ data, loading, error }] = useAxios(
+    {
+      url: `/api/fairness?month=${month}&year=${year}`,
+      method: "GET",
+    },
+    { useCache: false }
+  );
+
+  const monthTH = dayjs().month(month).format("MMMM");
+  const yearTH = (year + 543).toString();
+
+  if (error) return <ErrorComponent />;
+  if (loading) return <LoadingComponent />;
+
+  // normalize: กันค่า undefined/NaN จากข้อมูลเก่าใน cache ให้เป็น 0 เสมอ
+  const NUM_KEYS = [
+    "morning", "afternoon", "night", "ot", "otMorning", "otAfternoon", "otNight",
+    "dayOff", "onCall", "weekendShifts", "workShifts", "totalShifts",
+    "dutyDays", "doubleShiftDays", "workloadScore",
+  ];
+  const staff = (data || []).map((s) => {
+    const c = { ...s };
+    NUM_KEYS.forEach((k) => {
+      if (!Number.isFinite(c[k])) c[k] = 0;
+    });
+    return c;
+  });
+
+  if (staff.length === 0) {
+    return (
+      <div className="p-12 text-center bg-white rounded-lg shadow">
+        <p className="text-gray-500">ไม่มีข้อมูลเวรในเดือน {monthTH} {yearTH}</p>
+      </div>
+    );
+  }
+
+  // ----- คำนวณค่าสรุป (ใช้ "คะแนนภาระงาน" เป็นตัววัดความเป็นธรรมหลัก) -----
+  const sum = (key) => staff.reduce((a, s) => a + s[key], 0);
+  const avg = (key) => sum(key) / staff.length;
+  const maxOf = (key) => Math.max(...staff.map((s) => s[key]));
+  const minOf = (key) => Math.min(...staff.map((s) => s[key]));
+  const fmt = (n) => (Number.isFinite(n) ? Math.round(n * 10) / 10 : 0).toFixed(1);
+
+  const avgScore = avg("workloadScore");
+  const avgTotal = avg("totalShifts");
+  const scoreRange = maxOf("workloadScore") - minOf("workloadScore");
+  const maxDev = Math.max(...staff.map((s) => Math.abs(s.workloadScore - avgScore)));
+  const balanced = maxDev <= 3;
+
+  const topName = (key) => {
+    const m = maxOf(key);
+    const p = staff.find((s) => s[key] === m);
+    return { name: `${p?.firstname || ""} ${p?.lastname || ""}`.trim(), value: m };
+  };
+  const nightTop = topName("night");
+  const doubleTop = topName("doubleShiftDays");
+
+  const maxScore = maxOf("workloadScore") || 1;
+  const nameOf = (s) => `${s.title || ""}${s.firstname || ""} ${s.lastname || ""}`.trim();
+
+  // สีของแถวตามคะแนนภาระงาน เทียบค่าเฉลี่ย
+  const loadClass = (score) => {
+    if (score >= avgScore + 3) return "bg-red-50";
+    if (score <= avgScore - 3) return "bg-green-50";
+    return "";
+  };
+
+  const Card = ({ label, value, sub, accent }) => (
+    <div className="p-4 bg-white rounded-lg border shadow-sm">
+      <div className="text-xs text-gray-500">{label}</div>
+      <div className={`text-2xl font-bold ${accent || "text-gray-800"}`}>{value}</div>
+      {sub && <div className="mt-0.5 text-xs text-gray-500">{sub}</div>}
+    </div>
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">สรุปความเป็นธรรมการจัดเวร</h1>
+        <p className="text-gray-600">ประจำเดือน {monthTH} พ.ศ. {yearTH} · {staff.length} คน</p>
+      </div>
+
+      {/* การ์ดสรุป */}
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <Card label="ภาระงานเฉลี่ย/คน" value={fmt(avgScore)} sub={`เวรเฉลี่ย ${fmt(avgTotal)} เวร`} />
+        <Card
+          label="สถานะความสมดุล"
+          value={balanced ? "สมดุลดี" : "ควรปรับ"}
+          sub={`ส่วนต่างภาระงานมาก-น้อย ${fmt(scoreRange)}`}
+          accent={balanced ? "text-green-600" : "text-amber-600"}
+        />
+        <Card label="เวรดึกมากสุด" value={nightTop.value} sub={nightTop.name} accent="text-indigo-600" />
+        <Card label="เวรควบมากสุด" value={doubleTop.value} sub={doubleTop.name} accent="text-rose-600" />
+      </div>
+
+      {/* กราฟแท่งคะแนนภาระงาน */}
+      <div className="p-5 bg-white rounded-lg border shadow-sm">
+        <h2 className="mb-1 text-lg font-medium">คะแนนภาระงานต่อคน</h2>
+        <p className="mb-4 text-xs text-gray-500">
+          ถ่วงน้ำหนัก: เช้า ×1.0, บ่าย ×1.2, ดึก ×1.5, ควบเช้า-บ่าย +0.5 · เส้นประ = ค่าเฉลี่ย ({fmt(avgScore)})
+        </p>
+        <div className="space-y-2">
+          {staff.map((s) => {
+            const over = s.workloadScore >= avgScore + 3;
+            const under = s.workloadScore <= avgScore - 3;
+            const barColor = over ? "bg-red-500" : under ? "bg-green-500" : "bg-indigo-500";
+            return (
+              <div key={s.id} className="flex items-center">
+                <div className="w-36 text-sm text-gray-700 truncate" title={nameOf(s)}>{nameOf(s)}</div>
+                <div className="relative flex-1 h-6 bg-gray-100 rounded">
+                  <div className={`h-6 rounded ${barColor}`} style={{ width: `${(s.workloadScore / maxScore) * 100}%` }} />
+                  <div className="absolute top-0 bottom-0 border-l-2 border-dashed border-gray-500" style={{ left: `${(avgScore / maxScore) * 100}%` }} />
+                  <div className="flex absolute inset-0 items-center pl-2 text-xs font-medium text-gray-800">
+                    {fmt(s.workloadScore)}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* ตารางรายละเอียด */}
+      <div className="overflow-x-auto bg-white rounded-lg border shadow-sm">
+        <table className="min-w-full text-sm text-center">
+          <thead className="text-gray-600 bg-gray-50">
+            <tr>
+              <th className="px-3 py-2 text-left">ชื่อ - สกุล</th>
+              <th className="px-2 py-2">เช้า</th>
+              <th className="px-2 py-2">บ่าย</th>
+              <th className="px-2 py-2">ดึก</th>
+              <th className="px-2 py-2 text-orange-600">OT</th>
+              <th className="px-2 py-2 text-rose-600">ควบ<br/>ช-บ</th>
+              <th className="px-2 py-2">เวรรวม</th>
+              <th className="px-2 py-2 font-bold text-indigo-700">ภาระงาน</th>
+              <th className="px-2 py-2">On-Call</th>
+              <th className="px-2 py-2">วันหยุด</th>
+              <th className="px-2 py-2">ส-อา</th>
+            </tr>
+          </thead>
+          <tbody>
+            {staff.map((s) => (
+              <tr key={s.id} className={`border-t ${loadClass(s.workloadScore)}`}>
+                <td className="px-3 py-2 text-left whitespace-nowrap">{nameOf(s)}</td>
+                <td className="px-2 py-2">{s.morning}</td>
+                <td className="px-2 py-2">{s.afternoon}</td>
+                <td className="px-2 py-2 font-medium text-indigo-700">{s.night}</td>
+                <td className="px-2 py-2 text-orange-600">{s.ot}</td>
+                <td className="px-2 py-2 text-rose-600">{s.doubleShiftDays}</td>
+                <td className="px-2 py-2">{s.totalShifts}</td>
+                <td className="px-2 py-2 font-bold text-indigo-700">{fmt(s.workloadScore)}</td>
+                <td className="px-2 py-2">{s.onCall}</td>
+                <td className="px-2 py-2 text-gray-500">{s.dayOff}</td>
+                <td className="px-2 py-2">{s.weekendShifts}</td>
+              </tr>
+            ))}
+          </tbody>
+          <tfoot className="font-medium text-gray-700 bg-gray-50 border-t-2">
+            <tr>
+              <td className="px-3 py-2 text-left">เฉลี่ย/คน</td>
+              <td className="px-2 py-2">{fmt(avg("morning"))}</td>
+              <td className="px-2 py-2">{fmt(avg("afternoon"))}</td>
+              <td className="px-2 py-2">{fmt(avg("night"))}</td>
+              <td className="px-2 py-2">{fmt(avg("ot"))}</td>
+              <td className="px-2 py-2">{fmt(avg("doubleShiftDays"))}</td>
+              <td className="px-2 py-2">{fmt(avgTotal)}</td>
+              <td className="px-2 py-2 font-bold">{fmt(avgScore)}</td>
+              <td className="px-2 py-2">{fmt(avg("onCall"))}</td>
+              <td className="px-2 py-2">{fmt(avg("dayOff"))}</td>
+              <td className="px-2 py-2">{fmt(avg("weekendShifts"))}</td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+
+      <p className="text-xs text-gray-400">
+        คะแนนภาระงาน = (เช้า×1.0) + (บ่าย×1.2) + (ดึก×1.5) + (ควบเช้า-บ่าย×0.5) ·
+        แถวสีแดง = ภาระมากกว่าเฉลี่ย ≥3 · แถวสีเขียว = น้อยกว่าเฉลี่ย ≥3 (ควรปรับให้สมดุลในเดือนถัดไป)
+      </p>
+    </div>
+  );
+};
+
+export default FairnessDashboard;

--- a/components/Fairness/FairnessSummaryCard.jsx
+++ b/components/Fairness/FairnessSummaryCard.jsx
@@ -1,0 +1,63 @@
+import useAxios from "axios-hooks";
+import Link from "next/link";
+
+// การ์ดสรุปความเป็นธรรมแบบย่อ สำหรับวางบนหน้า Home
+const FairnessSummaryCard = ({ month, year }) => {
+  const [{ data, loading }] = useAxios(
+    { url: `/api/fairness?month=${month}&year=${year}`, method: "GET" },
+    { useCache: false }
+  );
+
+  const staff = (data || []).filter((s) => Number.isFinite(s?.workloadScore));
+  // ไม่แสดงการ์ดถ้ายังไม่มีเวรในเดือนนั้น
+  const hasData = staff.length > 0 && staff.some((s) => s.workloadScore > 0);
+
+  if (loading || !hasData) return null;
+
+  const scores = staff.map((s) => s.workloadScore);
+  const avg = scores.reduce((a, b) => a + b, 0) / scores.length;
+  const maxScore = Math.max(...scores);
+  const minScore = Math.min(...scores);
+  const maxDev = Math.max(...scores.map((s) => Math.abs(s - avg)));
+  const balanced = maxDev <= 3;
+  const fmt = (n) => (Math.round(n * 10) / 10).toFixed(1);
+
+  const top = staff.find((s) => s.workloadScore === maxScore);
+  const bottom = staff.find((s) => s.workloadScore === minScore);
+  const nameOf = (s) => `${s?.firstname || ""} ${s?.lastname || ""}`.trim();
+
+  return (
+    <div className="p-4 bg-white rounded-xl border shadow-sm">
+      <div className="flex flex-wrap gap-4 justify-between items-center">
+        <div className="flex flex-wrap gap-x-8 gap-y-3 items-center">
+          <div>
+            <div className="text-xs text-gray-500">ความเป็นธรรมการจัดเวร</div>
+            <div className={`text-lg font-bold ${balanced ? "text-green-600" : "text-amber-600"}`}>
+              {balanced ? "สมดุลดี" : "ควรปรับให้สมดุล"}
+            </div>
+          </div>
+          <div>
+            <div className="text-xs text-gray-500">ภาระงานเฉลี่ย/คน</div>
+            <div className="text-lg font-semibold text-gray-800">{fmt(avg)}</div>
+          </div>
+          <div>
+            <div className="text-xs text-gray-500">ภาระมากสุด</div>
+            <div className="text-sm font-medium text-red-600">{nameOf(top)} ({fmt(maxScore)})</div>
+          </div>
+          <div>
+            <div className="text-xs text-gray-500">ภาระน้อยสุด</div>
+            <div className="text-sm font-medium text-green-600">{nameOf(bottom)} ({fmt(minScore)})</div>
+          </div>
+        </div>
+        <Link
+          href="/fairness"
+          className="px-4 py-2 text-sm font-semibold text-green-700 whitespace-nowrap rounded-lg border border-green-700 hover:bg-green-50"
+        >
+          ดูรายละเอียด →
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default FairnessSummaryCard;

--- a/components/Home/TodayBoard.jsx
+++ b/components/Home/TodayBoard.jsx
@@ -1,0 +1,160 @@
+import useAxios from "axios-hooks";
+import dayjs from "dayjs";
+import { authProvider } from "src/authProvider";
+
+const SHIFT_INFO = {
+  ช: { label: "เช้า", time: "08:30–16:30", chip: "bg-amber-100 text-amber-800", dot: "bg-amber-400" },
+  บ: { label: "บ่าย", time: "16:30–00:30", chip: "bg-sky-100 text-sky-800", dot: "bg-sky-400" },
+  ด: { label: "ดึก", time: "00:30–08:30", chip: "bg-indigo-100 text-indigo-800", dot: "bg-indigo-400" },
+  x: { label: "หยุด", time: "", chip: "bg-gray-100 text-gray-600", dot: "bg-gray-300" },
+};
+
+const nameOf = (u) => `${u?.firstname || ""} ${u?.lastname || ""}`.trim();
+
+const TodayBoard = ({ month, year }) => {
+  const me = authProvider.getIdentity();
+
+  const [{ data, loading }] = useAxios({
+    url: `/api/user/selectMonth?month=${month}&year=${year}`,
+    method: "GET",
+  });
+
+  if (loading || !data) return null;
+
+  const users = Array.isArray(data) ? data.filter((u) => u?.firstname) : [];
+  if (users.length === 0) return null;
+
+  // วันอ้างอิง = วันนี้ ถ้าเดือน/ปีที่เลือกคือเดือนปัจจุบัน
+  const now = dayjs();
+  const isCurrentMonth = now.month() === month && now.year() === year;
+  const refDay = isCurrentMonth ? now.date() : null;
+
+  // เวรของ user ในวันที่กำหนด (เฉพาะกะทำงาน/หยุดหลัก)
+  const dutiesOn = (u, day) =>
+    (u.Duty || []).filter((d) => dayjs(d.datetime).date() === day);
+
+  // ---- เข้าเวรวันนี้: จัดกลุ่มตามกะ ----
+  const groupByShift = (day) => {
+    const g = { ช: [], บ: [], ด: [] };
+    users.forEach((u) => {
+      dutiesOn(u, day).forEach((d) => {
+        const n = d.Shif?.name;
+        if (g[n]) g[n].push({ user: u, ot: d.isOT || d.Shif?.isOT });
+      });
+    });
+    return g;
+  };
+
+  // ---- เวร/สถิติของฉัน ----
+  const myData = me?.id ? users.find((u) => u.id === me.id) : null;
+  const myToday = refDay && myData ? dutiesOn(myData, refDay) : [];
+
+  const monthStat = (u) => {
+    const reg = (name) => (u.Duty || []).filter((d) => d.Shif?.name === name && !(d.isOT || d.Shif?.isOT)).length;
+    const ot = (u.Duty || []).filter((d) => d.isOT || d.Shif?.isOT).length;
+    const off = (u.Duty || []).filter((d) => ["x", "R"].includes(d.Shif?.name)).length;
+    return { morning: reg("ช"), afternoon: reg("บ"), night: reg("ด"), ot, off, work: reg("ช") + reg("บ") + reg("ด") };
+  };
+
+  const todayGroups = refDay ? groupByShift(refDay) : null;
+  const monthLabel = dayjs().month(month).format("MMMM");
+
+  const ShiftChip = ({ name }) => {
+    const info = SHIFT_INFO[name] || SHIFT_INFO.x;
+    return (
+      <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${info.chip}`}>
+        {info.label}{info.time ? ` · ${info.time}` : ""}
+      </span>
+    );
+  };
+
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+      {/* การ์ดเวรของฉัน + เพื่อนร่วมกะ */}
+      <div className="p-4 bg-white rounded-xl border shadow-sm lg:col-span-1">
+        <div className="mb-2 text-sm font-semibold text-gray-700">เวรของฉัน{refDay ? " วันนี้" : ` เดือน${monthLabel}`}</div>
+        {!myData ? (
+          <p className="text-sm text-gray-400">ไม่พบข้อมูลเวรของคุณ</p>
+        ) : refDay ? (
+          myToday.length === 0 ? (
+            <p className="text-sm text-gray-400">วันนี้ไม่มีเวร / ยังไม่จัด</p>
+          ) : (
+            <div className="space-y-2">
+              <div className="flex flex-wrap gap-1">
+                {myToday.map((d, i) => <ShiftChip key={i} name={d.Shif?.name} />)}
+              </div>
+              {/* เพื่อนร่วมกะวันนี้ */}
+              {myToday
+                .filter((d) => ["ช", "บ", "ด"].includes(d.Shif?.name))
+                .map((d, i) => {
+                  const mates = users.filter(
+                    (u) => u.id !== myData.id && dutiesOn(u, refDay).some((x) => x.Shif?.name === d.Shif?.name)
+                  );
+                  return (
+                    <div key={i} className="text-xs text-gray-600">
+                      <span className="font-medium">เพื่อนร่วมกะ{SHIFT_INFO[d.Shif?.name]?.label}:</span>{" "}
+                      {mates.length ? mates.map(nameOf).join(", ") : "—"}
+                    </div>
+                  );
+                })}
+            </div>
+          )
+        ) : (
+          <p className="text-sm text-gray-400">เลือกเดือนปัจจุบันเพื่อดูเวรวันนี้</p>
+        )}
+
+        {/* สรุปเดือนของฉัน */}
+        {myData && (
+          <div className="grid grid-cols-4 gap-2 pt-3 mt-3 text-center border-t">
+            {(() => { const s = monthStat(myData); return (
+              <>
+                <div><div className="text-base font-bold text-gray-800">{s.work}</div><div className="text-[11px] text-gray-500">เวร</div></div>
+                <div><div className="text-base font-bold text-indigo-700">{s.night}</div><div className="text-[11px] text-gray-500">ดึก</div></div>
+                <div><div className="text-base font-bold text-orange-600">{s.ot}</div><div className="text-[11px] text-gray-500">OT</div></div>
+                <div><div className="text-base font-bold text-gray-500">{s.off}</div><div className="text-[11px] text-gray-500">หยุด</div></div>
+              </>
+            ); })()}
+          </div>
+        )}
+      </div>
+
+      {/* การ์ดเข้าเวรวันนี้ */}
+      <div className="p-4 bg-white rounded-xl border shadow-sm lg:col-span-2">
+        <div className="mb-3 text-sm font-semibold text-gray-700">
+          {refDay ? `เข้าเวรวันนี้ (${now.format("D MMM")})` : `เลือกเดือนปัจจุบันเพื่อดูผู้เข้าเวรวันนี้`}
+        </div>
+        {refDay && todayGroups && (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            {["ช", "บ", "ด"].map((s) => {
+              const info = SHIFT_INFO[s];
+              const list = todayGroups[s];
+              return (
+                <div key={s} className="p-3 rounded-lg border bg-gray-50">
+                  <div className="flex justify-between items-center mb-2">
+                    <span className="flex gap-1.5 items-center text-sm font-medium text-gray-700">
+                      <span className={`w-2 h-2 rounded-full ${info.dot}`} />{info.label}
+                    </span>
+                    <span className="text-xs text-gray-500">{list.length} คน</span>
+                  </div>
+                  <div className="space-y-0.5">
+                    {list.length === 0 ? (
+                      <div className="text-xs text-gray-400">—</div>
+                    ) : (
+                      list.map(({ user, ot }, i) => (
+                        <div key={i} className={`text-xs ${user.id === me?.id ? "font-bold text-green-700" : "text-gray-700"}`}>
+                          {nameOf(user)}{ot ? " (OT)" : ""}
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TodayBoard;

--- a/components/Navbar/DefaultNavbar.jsx
+++ b/components/Navbar/DefaultNavbar.jsx
@@ -34,6 +34,12 @@ export default function DefaultNavbar() {
                 สรุปยอดตารางเวรประจำเดือน
               </Link>
               <Link
+                href="/reservation"
+                className="text-gray-800 text-sm font-semibold hover:text-green-700 mr-4"
+              >
+                จองเวร
+              </Link>
+              <Link
                 href="/on-call"
                 className="text-gray-800 text-sm font-semibold hover:text-green-700 mr-4"
               >
@@ -59,6 +65,12 @@ export default function DefaultNavbar() {
                   จัดตารางอัตโนมัติ
                 </Link>
               )}
+              <Link
+                href="/fairness"
+                className="text-gray-800 text-sm font-semibold hover:text-green-700 mr-4"
+              >
+                สรุปความเป็นธรรม
+              </Link>
             </div>
 
             <div className="hidden sm:flex sm:items-center">
@@ -110,6 +122,12 @@ export default function DefaultNavbar() {
                 สรุปยอดตารางเวรประจำเดือน
               </Link>
               <Link
+                href="/reservation"
+                className="text-gray-800 text-sm font-semibold hover:text-green-700 mb-1 flex justify-center"
+              >
+                จองเวร
+              </Link>
+              <Link
                 href="/on-call"
                 className="text-gray-800 text-sm font-semibold hover:text-green-700 mb-1 flex justify-center"
               >
@@ -138,6 +156,13 @@ export default function DefaultNavbar() {
                   จัดตารางอัตโนมัติ
                 </Link>
               )}
+
+              <Link
+                href="/fairness"
+                className="text-gray-800 text-sm font-semibold hover:text-green-700 mb-1 flex justify-center"
+              >
+                สรุปความเป็นธรรม
+              </Link>
 
               <div className="flex justify-center items-center border-t-2 pt-2">
                 <Link

--- a/components/OfficialScheduleTable/OfficialScheduleTable.jsx
+++ b/components/OfficialScheduleTable/OfficialScheduleTable.jsx
@@ -28,6 +28,12 @@ const OfficialScheduleTable = ({ month, year, locationFilter = null, generatedSc
     method: "GET"
   });
 
+  // ดึงข้อมูลกะทั้งหมด เพื่อ map shifId → ชื่อกะ (รวมกะ OT ที่ไม่ได้อยู่ใน map แบบ hardcode)
+  const [{ data: shifData }] = useAxios({
+    url: "/api/shif",
+    method: "GET"
+  });
+
 
 
   // กรองข้อมูลตามแผนกที่เลือก
@@ -148,15 +154,17 @@ const OfficialScheduleTable = ({ month, year, locationFilter = null, generatedSc
     return summary;
   };
 
-  // ฟังก์ชันสำหรับแปลงชื่อเวร
+  // ฟังก์ชันสำหรับแปลงชื่อเวร — ใช้ข้อมูลกะจริงจาก /api/shif ก่อน (ครอบคลุมกะ OT)
   function getShiftName(shifId) {
+    const fromDb = shifData?.find((s) => s.id === shifId);
+    if (fromDb) return fromDb.name;
+
     const shiftMap = {
       "66c74ecaaf47d3097ba9acb3": "ช", // เช้า
       "66c74ecaaf47d3097ba9acb4": "บ", // บ่าย
       "66c74ecaaf47d3097ba9acb5": "ด", // ดึก
       "66c74ecaaf47d3097ba9acb6": "x", // วันหยุด
     };
-    
     return shiftMap[shifId] || "ไม่ทราบ";
   }
 

--- a/components/ShiftReservation/ShiftReservationModal.jsx
+++ b/components/ShiftReservation/ShiftReservationModal.jsx
@@ -78,8 +78,9 @@ const ShiftReservationModal = ({
 
   if (!isOpen) return null;
 
-  const availableShifts = shifts?.filter(shift => 
-    shift.isShif && ["ช", "บ", "ด"].includes(shift.name)
+  // รวมกะทำงาน (ช/บ/ด) และวันหยุด (x) ให้จองได้
+  const availableShifts = shifts?.filter(shift =>
+    (shift.isShif && ["ช", "บ", "ด"].includes(shift.name)) || shift.name === "x"
   ) || [];
 
   const currentDateReservations = existingReservations?.filter(res => 
@@ -127,7 +128,9 @@ const ShiftReservationModal = ({
                 <option value="">-- เลือกกะงาน --</option>
                 {availableShifts.map(shift => (
                   <option key={shift.id} value={shift.id}>
-                    {shift.name} ({getShiftTime(shift.name)})
+                    {shift.name === "x"
+                      ? "หยุด (วันหยุด)"
+                      : `${shift.name} (${getShiftTime(shift.name)})`}
                   </option>
                 ))}
               </select>

--- a/components/TableSelectMonth/TableSelectMonth.jsx
+++ b/components/TableSelectMonth/TableSelectMonth.jsx
@@ -251,21 +251,24 @@ export const TableSelectMonth = ({
               </tr>
               <tr className="border">
                 {/* จำนวนวันของเดือน */}
-                {arrayDayInMonth.map((day, index) => (
-                  <td
-                    key={index}
-                    className={`border border-black text-black  min-w-[40px] ${["เสาร์", "อาทิตย์"].includes(
-                      dayjs(`${yearEN}-${+monthValue + 1}-${day + 1}`).format(
-                        "dddd"
-                      )
-                    )
-                        ? "bg-white"
-                        : "bg-white"
+                {arrayDayInMonth.map((day, index) => {
+                  const isToday =
+                    day + 1 === dayjs().date() &&
+                    +monthValue === dayjs().month() &&
+                    +yearEN === dayjs().year();
+                  return (
+                    <td
+                      key={index}
+                      className={`border min-w-[40px] ${
+                        isToday
+                          ? "bg-green-200 text-green-900 font-bold ring-2 ring-green-500 ring-inset border-green-600"
+                          : "border-black text-black bg-white"
                       } `}
-                  >
-                    <div className="text-base">{day + 1}</div>
-                  </td>
-                ))}
+                    >
+                      <div className="text-base">{day + 1}</div>
+                    </td>
+                  );
+                })}
                 <td className="border border-black bg-white text-black min-w-[30px]">
                   <div className="text-sm">บ</div>
                 </td>

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "react-redux": "^8.0.5",
     "react-to-print": "^2.14.11",
     "react-toastify": "^9.1.2",
-    "thai-baht-text": "^1.0.8"
+    "thai-baht-text": "^1.0.8",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.13",

--- a/pages/api/auto-schedule/apply.js
+++ b/pages/api/auto-schedule/apply.js
@@ -10,7 +10,7 @@ export default async function handler(req, res) {
   }
 
   try {
-    const { schedule, locationId, month, year, weeks } = req.body;
+    const { schedule, locationId, month, year, weeks, replaceExisting } = req.body;
 
     if (!schedule || !Array.isArray(schedule)) {
       return res.status(400).json({ error: "Schedule array is required" });
@@ -20,13 +20,28 @@ export default async function handler(req, res) {
       return res.status(400).json({ error: "Location ID is required" });
     }
 
-    console.log(`Applying auto schedule for ${month}/${year}, ${weeks} weeks, location: ${locationId}`);
+    console.log(`Applying auto schedule for ${month}/${year}, ${weeks} weeks, location: ${locationId}, replaceExisting: ${replaceExisting}`);
     console.log(`Total schedule items: ${schedule.length}`);
 
     // เริ่ม transaction
     const result = await prisma.$transaction(async (tx) => {
       const appliedSchedule = [];
       const errors = [];
+      let deletedCount = 0;
+
+      // ถ้าเลือกแทนที่ของเดิม: ลบเวรเดิมของแผนกนี้ในเดือนที่เลือกทั้งหมดก่อน
+      if (replaceExisting && month != null && year != null) {
+        const firstDay = dayjs().year(year).month(month).startOf("month").toDate();
+        const lastDay = dayjs().year(year).month(month).endOf("month").toDate();
+        const deleted = await tx.duty.deleteMany({
+          where: {
+            locationId: locationId,
+            datetime: { gte: firstDay, lte: lastDay },
+          },
+        });
+        deletedCount = deleted.count;
+        console.log(`Replace mode: deleted ${deletedCount} existing duties`);
+      }
 
       for (const item of schedule) {
         try {
@@ -80,8 +95,7 @@ export default async function handler(req, res) {
               where: { id: existingDuty.id },
               data: {
                 shifId: item.shifId,
-                isOT: item.isOT || false,
-                isOnCall: item.isOnCall || false
+                isOT: item.isOT || false
               }
             });
 
@@ -101,8 +115,7 @@ export default async function handler(req, res) {
                 shifId: item.shifId,
                 locationId: locationId,
                 datetime: new Date(item.datetime),
-                isOT: item.isOT || false,
-                isOnCall: item.isOnCall || false
+                isOT: item.isOT || false
               }
             });
 
@@ -147,9 +160,12 @@ export default async function handler(req, res) {
         errors,
         summary: {
           totalItems: schedule.length,
-          applied: appliedSchedule.length,
+          created: appliedSchedule.length,
+          deleted: deletedCount,
           errors: errors.length,
-          successRate: ((appliedSchedule.length / schedule.length) * 100).toFixed(2) + "%"
+          successRate: schedule.length > 0
+            ? ((appliedSchedule.length / schedule.length) * 100).toFixed(2) + "%"
+            : "0%"
         }
       };
 
@@ -158,6 +174,7 @@ export default async function handler(req, res) {
     res.status(200).json({
       success: true,
       message: "Auto schedule applied successfully",
+      summary: result.summary,
       data: result
     });
 

--- a/pages/api/auto-schedule/index.js
+++ b/pages/api/auto-schedule/index.js
@@ -41,8 +41,8 @@ const SHIFT_RULES = {
   H1: { description: "Rest หลังเวรเดี่ยว ≥ 12 ชม.", minRestHours: 12 },
   H2: { description: "Rest หลังเวรควบ ≥ 24 ชม.", minRestHours: 24 },
   H3: { description: "Rest หลัง On-Call ≥ 12 ชม.", minRestHours: 12 },
-  H4: { description: "ไม่เกิน 4 N ภายใน 14 วัน", maxNightPer14d: 4 },
-  H5: { description: "ไม่เกิน 2 เวรควบ/เดือน/คน และคั่น ≥ 3 วัน", maxDoublePerMonth: 2, minDaysBetweenDouble: 3 },
+  H4: { description: "ไม่เกิน 6 N ภายใน 14 วัน (อิงเวรจริง ดึก ~7/เดือน)", maxNightPer14d: 6 },
+  H5: { description: "เวรควบ ≤ 10/เดือน/คน และคั่น ≥ 1 วัน (อิงเวรจริง ~7/เดือน)", maxDoublePerMonth: 10, minDaysBetweenDouble: 1 },
   H6: { description: "ไม่เกิน 4 On-Call/เดือน/คน และห้าม OC ติด OC", maxOnCallPerMonth: 4, noConsecutiveOnCall: true },
   H7: { description: "เวรชนิดเดียวกันติดกันได้สูงสุด 2 ครั้ง", maxConsecutiveSame: 2 },
   H8: { description: "ลูปหมุนมาตรฐาน: ด → ช → บ", rotationPattern: ["ด", "ช", "บ"] },
@@ -140,18 +140,19 @@ export default async function handler(req, res) {
   }
 
   try {
-    const { month, year, locationId, weeks = 4 } = req.body;
+    const { month, year, locationId } = req.body;
 
     if (!month || !year) {
       return res.status(400).json({ error: "Month and year are required" });
     }
 
-    console.log(`Generating auto schedule for ${month}/${year}, ${weeks} weeks, location: ${locationId}`);
-
-    // ดึงข้อมูลที่จำเป็น
+    // จัดตารางให้ครอบคลุม "ทั้งเดือนจริง" (30/31 วัน) ไม่ใช่แค่ 4 สัปดาห์ (28 วัน)
     const startDate = dayjs().month(month).year(year).startOf("month");
-    const endDate = startDate.add(weeks, "weeks").subtract(1, "day");
+    const endDate = dayjs().month(month).year(year).endOf("month");
     const totalDays = endDate.diff(startDate, "day") + 1;
+    const weeks = Math.ceil(totalDays / 7);
+
+    console.log(`Generating auto schedule for ${month}/${year}, ${totalDays} days (${weeks} weeks), location: ${locationId}`);
 
     // ดึงรายชื่อพนักงาน
     const staff = await getActiveStaff(locationId, month, year);
@@ -247,6 +248,8 @@ export default async function handler(req, res) {
     res.status(200).json({
       success: true,
       schedule: schedule.schedule,
+      violations: schedule.violations || [],
+      staffStats: schedule.staffStats || {},
       summary: {
         totalStaff: staff.length,
         specialStaff: specialStaff.length,
@@ -419,10 +422,10 @@ async function getAvailableShifts() {
       "x": "x" // วันหยุด
     };
     
-    // กรองเวรที่ต้องการ - ใช้เวรทั้งหมดที่มีอยู่
+    // กรองเวรที่ต้องการ - รวมกะ OT (isOT=true) ด้วย เพื่อให้จัดเวร OT/เวรควบได้
     const filteredShifts = allShifts.filter(shift => {
       const mappedName = shiftMapping[shift.name];
-      return mappedName && (mappedName === "x" || shift.isShif === true);
+      return mappedName && (mappedName === "x" || shift.isShif === true || shift.isOT === true);
     });
     
     // ถ้าไม่มีเวรที่กรองแล้ว ให้ใช้เวรทั้งหมด
@@ -472,25 +475,29 @@ async function generateAdvancedAutoSchedule({ staff, specialStaff, normalStaff, 
   const reservationMap = createReservationMap(preferences);
 
   // กำหนดจำนวนเวรแต่ละกะ/วัน - ตามเงื่อนไขใหม่
+  // จำนวนเวร "regular" ต่อกะต่อวัน อิงจากเวรจริงของ ICU (เฉลี่ย มี.ค.–พ.ค. 2026)
+  // หมายเหตุ: on-call จัดแยกใน OnCallDuty ไม่ใช่ที่นี่ → oncall = 0
   const SHIFT_REQUIREMENTS = {
-    "ช": { regular: 4, oncall: 1 },
-    "บ": { regular: 2, oncall: 1 },
-    "ด": { regular: 2, oncall: 1 }
+    "ช": { regular: 2, oncall: 0 },
+    "บ": { regular: 2, oncall: 0 },
+    "ด": { regular: 2, oncall: 0 }
+  };
+
+  // วันหยุด (เสาร์-อาทิตย์/นักขัตฤกษ์): เวรเช้า regular ลดเหลือ 1 (จากเวรจริง weekend ช≈0–1)
+  const WEEKEND_REQUIREMENTS = {
+    "ช": { regular: 1, oncall: 0 },
+    "บ": { regular: 2, oncall: 0 },
+    "ด": { regular: 2, oncall: 0 }
   };
 
   // ฟังก์ชันสำหรับดึงจำนวนเวรที่ต้องการตามวัน
   function getShiftRequirements(shiftName, currentDate) {
     const baseReq = SHIFT_REQUIREMENTS[shiftName];
     if (!baseReq) return { regular: 0, oncall: 0 };
-    
-    // เสาร์-อาทิตย์ และวันหยุดนักขัตฤกษ์: ลดจำนวนเวร
+
     if (isWeekendOrHoliday(currentDate)) {
-      return { 
-        regular: Math.max(1, Math.floor(baseReq.regular * 0.7)), 
-        oncall: baseReq.oncall 
-      };
+      return WEEKEND_REQUIREMENTS[shiftName] || baseReq;
     }
-    
     return baseReq;
   }
 
@@ -521,14 +528,15 @@ async function generateAdvancedAutoSchedule({ staff, specialStaff, normalStaff, 
     // Assign เวรหลัก (M, A, N)
     assignMainShifts(schedule, staffStats, currentDate, locationId, shifts, SHIFT_REQUIREMENTS, getShiftRequirements, reservationMap, violations);
 
-    // Assign เวรควบ (MA, NA) ตามโอกาส (เฉพาะกลุ่มทั่วไป)
-    assignDoubleShifts(schedule, staffStats, currentDate, locationId, shifts, violations, reservationMap);
-
-    // Assign On-Call (เฉพาะกลุ่มทั่วไป)
-    assignOnCallShifts(schedule, staffStats, currentDate, locationId, shifts, violations, reservationMap);
+    // Assign OT เช้า + เวรควบ (ช(OT)+บ, ด+บ(OT)) ตามรูปแบบจริง
+    // หมายเหตุ: on-call จัดแยกใน OnCallDuty ไม่ทำที่นี่
+    assignOTAndDoubles(schedule, staffStats, currentDate, locationId, shifts);
 
     // ตรวจสอบและแก้ไขข้อขัดแย้ง
-    resolveConflicts(schedule, staffStats, currentDate, violations);
+    resolveConflicts(schedule, staffStats, currentDate, violations, shifts);
+
+    // เติมวันหยุด (x) ให้คนที่ยังไม่มีเวร/หยุดในวันนี้ เพื่อไม่ให้เหลือช่องว่าง
+    fillRemainingAsOff(schedule, staffStats, currentDate, locationId, shifts);
   }
 
   // คำนวณคะแนนเป้าหมาย
@@ -723,8 +731,9 @@ function assignSpecialWeekendOffs(schedule, staffStats, currentDate, locationId,
 }
 
 function assignMainShifts(schedule, staffStats, currentDate, locationId, shifts, SHIFT_REQUIREMENTS, getShiftRequirements, reservationMap, violations) {
-  // ใช้ลำดับการหมุนเวรตามที่กำหนด: ด → ช → บ
-  const shiftTypes = SHIFT_RULES.H15.rotationPattern;
+  // จัดดึก/บ่ายก่อนเช้า เพราะเวรเช้ามี OT เสริม (ช OT) อยู่แล้ว
+  // ถ้าจัดเช้าก่อนจะแย่งคนจนดึก/บ่ายไม่ครบ
+  const shiftTypes = ["ด", "บ", "ช"];
   
   for (const shiftType of shiftTypes) {
     // หาเวรที่ตรงกับ shiftType (รองรับทั้งเวรเก่าและใหม่)
@@ -765,54 +774,117 @@ function assignMainShifts(schedule, staffStats, currentDate, locationId, shifts,
         datetime: currentDate.toDate(),
         isOT: false,
         isOnCall: false,
+        shiftType: shiftType,
         assignedBy: "auto-main"
       });
-      
+
       updateStaffStats(staffStats[selectedStaff.id], shiftType, currentDate);
+      // บันทึกว่าวันนี้ทำกะนี้แล้ว เพื่อให้จัดเวร OT/ควบต่อยอดได้ และกันเวรหลักซ้ำ
+      staffStats[selectedStaff.id].assignedShiftsToday.push(shiftType);
       assignedCount++;
     }
   }
 }
 
-function assignDoubleShifts(schedule, staffStats, currentDate, locationId, shifts, violations, reservationMap = {}) {
-  // ใช้เฉพาะเวรควบที่อนุญาตตาม H14
-  const allowedDoubleShifts = SHIFT_RULES.H14.allowedShifts.filter(shift => 
-    shift.includes('/') && !shift.startsWith('OC') && !shift.endsWith('OC')
-  );
-  
-  for (const shiftType of allowedDoubleShifts) {
-    // หาเวรที่ตรงกับ shiftType (รองรับทั้งเวรเก่าและใหม่)
-    const shiftObj = shifts.find(s => {
-      const mappedName = getShiftTypeById(s.name);
-      return mappedName === shiftType;
+// หา Shif object ตามชื่อกะ + สถานะ OT + สี (class)
+function findShiftObj(shifts, name, { isOT = false, cls = null } = {}) {
+  const matches = shifts.filter((s) => s.name === name && !!s.isOT === !!isOT);
+  if (cls) {
+    const byClass = matches.find((s) => s.class === cls);
+    if (byClass) return byClass;
+  }
+  return matches[0] || null;
+}
+
+// จัดเวร OT และเวรควบตามรูปแบบจริงของ ICU (อิงเวรจริง มี.ค.–พ.ค. 2026):
+//  - เช้า OT (circle-dark) ~2 คน/วันธรรมดา มักทำควบกับบ่าย → เวรควบ ช(OT)+บ (เด่นสุด)
+//  - บ่าย OT (circle-red) ~1 คน/วันธรรมดา มักทำควบกับดึก → เวรควบ ด+บ(OT)
+// เก็บเป็น 2 Duty แยกในวันเดียว (DB ไม่มีกะ "ช/บ"); on-call จัดแยกใน OnCallDuty จึงไม่ทำที่นี่
+function assignOTAndDoubles(schedule, staffStats, currentDate, locationId, shifts) {
+  const weekend = isWeekendOrHoliday(currentDate);
+  const chOT = findShiftObj(shifts, "ช", { isOT: true, cls: "circle-dark" });
+  const baOT = findShiftObj(shifts, "บ", { isOT: true, cls: "circle-red" });
+
+  const pushOT = (userId, shiftObj, baseType) => {
+    const stats = staffStats[userId];
+    schedule.push({
+      userId,
+      shifId: shiftObj.id,
+      locationId,
+      datetime: currentDate.toDate(),
+      isOT: true,
+      isOnCall: false,
+      shiftType: baseType,
+      assignedBy: "auto-ot",
     });
-    
-    if (!shiftObj) {
-      console.log(`No double shift found for type: ${shiftType}`);
-      continue;
+    stats.shiftCounts[baseType] = (stats.shiftCounts[baseType] || 0) + 1;
+    stats.totalWorkload += SHIFT_WEIGHTS[baseType]?.weight || 1;
+    const becomesDouble = stats.assignedShiftsToday.length >= 1;
+    stats.assignedShiftsToday.push(baseType);
+    if (becomesDouble) {
+      stats.doubleShiftCount++;
+      stats.lastDoubleShiftDate = currentDate;
     }
-    
-    // ตรวจสอบโอกาสในการ assign เวรควบ (เฉพาะกลุ่มทั่วไป)
-    if (Math.random() < 0.3) { // 30% โอกาส
-      const availableStaff = getAvailableStaffForDoubleShift(staffStats, shiftType, currentDate, violations);
-      
-      if (availableStaff.length > 0) {
-        const selectedStaff = selectBestStaff(availableStaff, staffStats, shiftType, currentDate, reservationMap);
-        
-        schedule.push({
-          userId: selectedStaff.id,
-          shifId: shiftObj.id,
-          locationId: locationId,
-          datetime: currentDate.toDate(),
-          isOT: false,
-          isOnCall: false,
-          assignedBy: "auto-double"
-        });
-        
-        updateStaffStats(staffStats[selectedStaff.id], shiftType, currentDate);
+  };
+
+  // เช้า OT — ให้คนที่ทำบ่ายอยู่แล้วก่อน (เวรควบ ช(OT)+บ) แล้วจึงคนว่าง
+  if (chOT) {
+    const target = weekend ? 0 : 2;
+    let n = 0;
+    const pick = (filterFn) => {
+      for (const [id, s] of Object.entries(staffStats)) {
+        if (n >= target) break;
+        if (SPECIAL_ROLES.includes(s.role)) continue;       // กลุ่มพิเศษไม่ทำ OT
+        if (s.assignedShiftsToday.includes("ช")) continue;  // มีเช้าแล้ว
+        if (s.doubleShiftCount >= SHIFT_RULES.H5.maxDoublePerMonth) continue;
+        if (!filterFn(s)) continue;
+        pushOT(id, chOT, "ช");
+        n++;
       }
+    };
+    pick((s) => s.assignedShiftsToday.includes("บ")); // ควบกับบ่าย
+    pick((s) => s.assignedShiftsToday.length === 0);  // คนว่าง (เช้า OT เดี่ยว)
+  }
+
+  // บ่าย OT — ให้คนที่ทำดึกอยู่แล้ว (เวรควบ ด+บ(OT)) เฉพาะวันธรรมดา
+  if (baOT && !weekend) {
+    const target = 1;
+    let n = 0;
+    for (const [id, s] of Object.entries(staffStats)) {
+      if (n >= target) break;
+      if (SPECIAL_ROLES.includes(s.role)) continue;
+      if (s.assignedShiftsToday.includes("บ")) continue;
+      if (!s.assignedShiftsToday.includes("ด")) continue;
+      if (s.doubleShiftCount >= SHIFT_RULES.H5.maxDoublePerMonth) continue;
+      pushOT(id, baOT, "บ");
+      n++;
     }
   }
+}
+
+// เติมวันหยุด (x) ให้พนักงานที่วันนี้ยังไม่มีเวรหรือวันหยุด เพื่อให้ตารางเต็มไม่มีช่องว่าง
+function fillRemainingAsOff(schedule, staffStats, currentDate, locationId, shifts) {
+  const offShift = shifts.find((s) => s.name === "x");
+  if (!offShift) return;
+  const dateStr = currentDate.format("YYYY-MM-DD");
+  Object.entries(staffStats).forEach(([userId, stats]) => {
+    const hasAny = schedule.some(
+      (s) => s.userId === userId && dayjs(s.datetime).format("YYYY-MM-DD") === dateStr
+    );
+    if (!hasAny) {
+      schedule.push({
+        userId,
+        shifId: offShift.id,
+        locationId,
+        datetime: currentDate.toDate(),
+        isOT: false,
+        isOnCall: false,
+        shiftType: "x",
+        assignedBy: "auto-fill-off",
+      });
+      stats.totalDayOffs++;
+    }
+  });
 }
 
 function assignOnCallShifts(schedule, staffStats, currentDate, locationId, shifts, violations, reservationMap = {}) {
@@ -936,19 +1008,8 @@ function isValidShiftAssignment(stats, shiftType, currentDate) {
     return false;
   }
   
-  // ตรวจสอบ H15: ลำดับการหมุนเวร ด → ช → บ (เฉพาะเวรเดี่ยว)
-  if (["ด", "ช", "บ"].includes(shiftType) && stats.lastShift && ["ด", "ช", "บ"].includes(stats.lastShift)) {
-    const rotationPattern = SHIFT_RULES.H15.rotationPattern;
-    const lastShiftIndex = rotationPattern.indexOf(stats.lastShift);
-    const currentShiftIndex = rotationPattern.indexOf(shiftType);
-    
-    // ตรวจสอบว่าตามลำดับการหมุนเวรหรือไม่
-    const expectedNextIndex = (lastShiftIndex + 1) % rotationPattern.length;
-    if (currentShiftIndex !== expectedNextIndex) {
-      return false;
-    }
-  }
-  
+  // หมายเหตุ: ไม่บังคับลำดับหมุนเวร ด→ช→บ แบบเป๊ะ (H15) เพราะเวรจริงของ ICU
+  // ไม่ได้หมุนตามลำดับนั้น การบังคับทำให้กรองคนออกมากจนจัดเวรไม่ครบ
   return true;
 }
 
@@ -1126,11 +1187,17 @@ function updateStaffStats(stats, shiftType, currentDate) {
   }
 }
 
-function resolveConflicts(schedule, staffStats, currentDate, violations) {
+function resolveConflicts(schedule, staffStats, currentDate, violations, shifts = []) {
   const dateStr = currentDate.format("YYYY-MM-DD");
-  
+
+  // map ObjectId ของกะ → ชื่อกะ (ช/บ/ด/x) เพื่อระบุชนิดเวรของ schedule item ได้ถูกต้อง
+  // (getShiftTypeById คืน null เมื่อรับ ObjectId)
+  const idToType = {};
+  shifts.forEach((s) => { idToType[s.id] = s.name; });
+  const typeOf = (item) => item.shiftType || idToType[item.shifId] || getShiftTypeById(item.shifId);
+
   // ตรวจสอบการขัดแย้งของเวรในวันเดียวกัน
-  const dailyShifts = schedule.filter(s => 
+  const dailyShifts = schedule.filter(s =>
     dayjs(s.datetime).format("YYYY-MM-DD") === dateStr
   );
   
@@ -1148,7 +1215,7 @@ function resolveConflicts(schedule, staffStats, currentDate, violations) {
     if (shifts.length > 1) {
       // ตรวจสอบเวรที่ไม่อนุญาตตาม H14
       shifts.forEach(shift => {
-        const shiftType = getShiftTypeById(shift.shifId);
+        const shiftType = typeOf(shift);
         if (!SHIFT_RULES.H14.allowedShifts.includes(shiftType)) {
           violations.push({
             type: "FORBIDDEN_SHIFT",
@@ -1174,8 +1241,8 @@ function resolveConflicts(schedule, staffStats, currentDate, violations) {
       const forbiddenPairs = [];
       for (let i = 0; i < shifts.length; i++) {
         for (let j = i + 1; j < shifts.length; j++) {
-          const shift1Type = getShiftTypeById(shifts[i].shifId);
-          const shift2Type = getShiftTypeById(shifts[j].shifId);
+          const shift1Type = typeOf(shifts[i]);
+          const shift2Type = typeOf(shifts[j]);
           
           if (SHIFT_RULES.H13.forbiddenConsecutive.includes(`${shift1Type}/${shift2Type}`) ||
               SHIFT_RULES.H13.forbiddenConsecutive.includes(`${shift2Type}/${shift1Type}`)) {
@@ -1186,8 +1253,8 @@ function resolveConflicts(schedule, staffStats, currentDate, violations) {
       
       // ลบเวรที่ขัดแย้งกับเงื่อนไขห้ามเวรซ้ำติดกัน
       forbiddenPairs.forEach(([shift1, shift2]) => {
-        const shift1Type = getShiftTypeById(shift1.shifId);
-        const shift2Type = getShiftTypeById(shift2.shifId);
+        const shift1Type = typeOf(shift1);
+        const shift2Type = typeOf(shift2);
         
         violations.push({
           type: "FORBIDDEN_CONSECUTIVE",
@@ -1215,7 +1282,7 @@ function resolveConflicts(schedule, staffStats, currentDate, violations) {
           // อัพเดทสถิติ
           const stats = staffStats[userId];
           if (stats) {
-            const shiftType = getShiftTypeById(shiftToRemove.shifId);
+            const shiftType = typeOf(shiftToRemove);
             if (shiftType) {
               stats.shiftCounts[shiftType] = Math.max(0, stats.shiftCounts[shiftType] - 1);
               stats.totalWorkload -= getShiftWeight({ id: userId, ...stats }, shiftType);
@@ -1232,7 +1299,7 @@ function resolveConflicts(schedule, staffStats, currentDate, violations) {
             userId: userId,
             date: dateStr,
             removedShift: shiftToRemove.shifId,
-            reason: `Forbidden consecutive shift: ${getShiftTypeById(shift1.shifId)}/${getShiftTypeById(shift2.shifId)}`
+            reason: `Forbidden consecutive shift: ${typeOf(shift1)}/${typeOf(shift2)}`
           });
         }
       });
@@ -1243,13 +1310,18 @@ function resolveConflicts(schedule, staffStats, currentDate, violations) {
         dayjs(s.datetime).format("YYYY-MM-DD") === dateStr
       );
       
-      if (remainingShifts.length > 1) {
+      // เวรควบที่ถูกต้องตามเวรจริง (ช+บ หรือ ด+บ) ไม่ต้องลบ
+      const baseTypes = [...new Set(remainingShifts.map(typeOf))].sort();
+      const pairKey = baseTypes.join("+");
+      const isAllowedDouble = remainingShifts.length === 2 && (pairKey === "ช+บ" || pairKey === "ด+บ");
+
+      if (remainingShifts.length > 1 && !isAllowedDouble) {
         const sortedShifts = remainingShifts.sort((a, b) => {
-          const aWeight = SHIFT_WEIGHTS[getShiftTypeById(a.shifId)]?.weight || 0;
-          const bWeight = SHIFT_WEIGHTS[getShiftTypeById(b.shifId)]?.weight || 0;
+          const aWeight = SHIFT_WEIGHTS[typeOf(a)]?.weight || 0;
+          const bWeight = SHIFT_WEIGHTS[typeOf(b)]?.weight || 0;
           return bWeight - aWeight;
         });
-        
+
         // ลบเวรที่มีน้ำหนักต่ำกว่า
         for (let i = 1; i < sortedShifts.length; i++) {
           const shiftToRemove = sortedShifts[i];
@@ -1265,7 +1337,7 @@ function resolveConflicts(schedule, staffStats, currentDate, violations) {
             // อัพเดทสถิติ
             const stats = staffStats[userId];
             if (stats) {
-              const shiftType = getShiftTypeById(shiftToRemove.shifId);
+              const shiftType = typeOf(shiftToRemove);
               if (shiftType) {
                 stats.shiftCounts[shiftType] = Math.max(0, stats.shiftCounts[shiftType] - 1);
                 stats.totalWorkload -= getShiftWeight({ id: userId, ...stats }, shiftType);
@@ -1290,70 +1362,12 @@ function resolveConflicts(schedule, staffStats, currentDate, violations) {
     }
   });
   
-  // ตรวจสอบการละเมิดข้อจำกัดการพักผ่อน
-  Object.entries(staffStats).forEach(([userId, stats]) => {
-    if (stats.lastShift && stats.lastShiftDate) {
-      const daysSinceLastShift = currentDate.diff(stats.lastShiftDate, "day");
-      const minRestHours = getMinRestHours(stats.lastShift);
-      const minRestDays = minRestHours / 24;
-      
-      if (daysSinceLastShift < minRestDays) {
-        // ลบเวรที่ขัดแย้งกับข้อจำกัดการพักผ่อน
-        const conflictingShifts = dailyShifts.filter(s => s.userId === userId);
-        conflictingShifts.forEach(shift => {
-          const removeIndex = schedule.findIndex(s => 
-            s.userId === shift.userId && 
-            s.datetime.getTime() === shift.datetime.getTime() &&
-            s.shifId === shift.shifId
-          );
-          
-          if (removeIndex !== -1) {
-            schedule.splice(removeIndex, 1);
-            
-            violations.push({
-              type: "INSUFFICIENT_REST",
-              userId: userId,
-              date: dateStr,
-              lastShift: stats.lastShift,
-              lastShiftDate: stats.lastShiftDate.format("YYYY-MM-DD"),
-              requiredRest: minRestHours,
-              actualRest: daysSinceLastShift * 24
-            });
-          }
-        });
-      }
-    }
-  });
-  
-  // ตรวจสอบการหมุนเวรตามลำดับ ด → ช → บ
-  Object.entries(staffStats).forEach(([userId, stats]) => {
-    if (stats.lastShift && ["ด", "ช", "บ"].includes(stats.lastShift)) {
-      const dailyShiftsForUser = dailyShifts.filter(s => s.userId === userId);
-      
-      dailyShiftsForUser.forEach(shift => {
-        const shiftType = getShiftTypeById(shift.shifId);
-        if (["ด", "ช", "บ"].includes(shiftType)) {
-          const rotationPattern = SHIFT_RULES.H15.rotationPattern;
-          const lastShiftIndex = rotationPattern.indexOf(stats.lastShift);
-          const currentShiftIndex = rotationPattern.indexOf(shiftType);
-          
-          // ตรวจสอบว่าตามลำดับการหมุนเวรหรือไม่
-          const expectedNextIndex = (lastShiftIndex + 1) % rotationPattern.length;
-          if (currentShiftIndex !== expectedNextIndex) {
-            violations.push({
-              type: "ROTATION_VIOLATION",
-              userId: userId,
-              date: dateStr,
-              lastShift: stats.lastShift,
-              currentShift: shiftType,
-              expectedShift: rotationPattern[expectedNextIndex],
-              description: `ไม่เป็นไปตามลำดับการหมุนเวร ด → ช → บ (${stats.lastShift} → ${shiftType})`
-            });
-          }
-        }
-      });
-    }
-  });
+  // หมายเหตุ: ไม่ตรวจ rest ซ้ำที่นี่ เพราะ isValidShiftAssignment เช็กเวลาพัก
+  // ตั้งแต่ตอน assign แล้ว (ตอนนั้น lastShiftDate ยังเป็นเวรก่อนหน้า เทียบได้ถูกต้อง)
+  // เดิมโค้ดส่วนนี้รัน "หลัง" updateStaffStats ทำให้ lastShiftDate = วันนี้
+  // → daysSinceLastShift = 0 < minRestDays → ลบเวรที่เพิ่งจัดทิ้งทุกอัน เหลือแต่ off
+
+  // ไม่รายงาน ROTATION_VIOLATION แล้ว (ด→ช→บ ไม่ใช่กฎที่เวรจริงทำตาม จึงเป็น noise)
 }
 
 // ฟังก์ชันช่วยสำหรับการแปลง shift ID เป็นชื่อเวร

--- a/pages/api/auto-schedule/index.js
+++ b/pages/api/auto-schedule/index.js
@@ -519,6 +519,9 @@ async function generateAdvancedAutoSchedule({ staff, specialStaff, normalStaff, 
       stats.assignedOnCallToday = false;
     });
 
+    // เคารพการจองแน่นอน (isReserved) ก่อน: จัดกะ/วันหยุดที่พยาบาลจองไว้
+    honorReservations(schedule, staffStats, currentDate, locationId, shifts, preferences);
+
     // Assign วันหยุดตามที่กำหนดไว้
     assignDayOffs(schedule, staffStats, dayOffSchedule, currentDate, locationId, shifts);
 
@@ -661,6 +664,42 @@ function generateBalancedDayOffs(staff, startDate, endDate, weeks) {
   return dayOffSchedule;
 }
 
+// เคารพการจอง "แน่นอน" (isReserved): จัดกะหรือวันหยุดที่พยาบาลจองไว้ก่อนการจัดอัตโนมัติ
+// - จอง x (หยุด) → ให้หยุดวันนั้น (กันไม่ให้ถูกจัดเวร)
+// - จอง ช/บ/ด → จัดกะนั้นให้แน่นอน
+function honorReservations(schedule, staffStats, currentDate, locationId, shifts, preferences) {
+  const dateStr = currentDate.format("YYYY-MM-DD");
+  const idToShift = {};
+  shifts.forEach((s) => { idToShift[s.id] = s; });
+
+  (preferences || [])
+    .filter((p) => p.isReserved && dayjs(p.datetime).format("YYYY-MM-DD") === dateStr)
+    .forEach((p) => {
+      const stats = staffStats[p.userId];
+      if (!stats || stats.assignedShiftsToday.length > 0) return; // จัดไปแล้ววันนี้
+      const shiftObj =
+        idToShift[p.shifId] ||
+        (p.Shif && shifts.find((s) => s.name === p.Shif.name && !s.isOT));
+      if (!shiftObj) return;
+      const name = shiftObj.name;
+
+      schedule.push({
+        userId: p.userId,
+        shifId: shiftObj.id,
+        locationId,
+        datetime: currentDate.toDate(),
+        isOT: !!shiftObj.isOT,
+        isOnCall: false,
+        shiftType: name,
+        assignedBy: "reserved",
+      });
+
+      if (["ช", "บ", "ด"].includes(name)) updateStaffStats(stats, name, currentDate);
+      stats.assignedShiftsToday.push(name);
+      if (["x", "R"].includes(name)) stats.totalDayOffs++;
+    });
+}
+
 function assignDayOffs(schedule, staffStats, dayOffSchedule, currentDate, locationId, shifts) {
   const dayIndex = currentDate.diff(dayjs().month(currentDate.month()).year(currentDate.year()).startOf("month"), "day");
   
@@ -676,7 +715,8 @@ function assignDayOffs(schedule, staffStats, dayOffSchedule, currentDate, locati
   }
   
   Object.entries(dayOffSchedule).forEach(([userId, days]) => {
-    if (days.includes(dayIndex)) {
+    // ข้ามถ้าวันนี้ถูกจัด (เช่น จองเวร/จองหยุดไว้แล้ว) เพื่อไม่ให้ซ้ำ
+    if (days.includes(dayIndex) && staffStats[userId].assignedShiftsToday.length === 0) {
       schedule.push({
         userId: userId,
         shifId: offShift.id,

--- a/pages/api/fairness/index.js
+++ b/pages/api/fairness/index.js
@@ -1,0 +1,134 @@
+import { prisma } from "@/utils/prisma";
+import dayjs from "dayjs";
+
+// น้ำหนักความหนักของแต่ละกะ — สะท้อนความอดนอน/โหลดงาน (ปรับค่าได้ที่นี่)
+// เช้า 1.0, บ่าย 1.2 (เลิก 00:30 กระทบการพักผ่อน), ดึก 1.5 (ทำกลางคืน หนักสุด)
+const SHIFT_WEIGHT = { ช: 1.0, บ: 1.2, ด: 1.5 };
+// โบนัสเวรควบ "เช้า-บ่าย" ที่ทำต่อเนื่อง 16 ชม. (08:30–00:30) หนักกว่าทำคนละวัน
+const DOUBLE_SHIFT_BONUS = 0.5;
+
+// สรุปสถิติความเป็นธรรมของการจัดเวรต่อคนในเดือนที่เลือก
+export default async function handler(req, res) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", ["GET"]);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  const month = parseInt(req.query.month);
+  const year = parseInt(req.query.year);
+  const firstDay = dayjs().month(month).year(year).startOf("month");
+  const lastDay = dayjs().month(month).year(year).endOf("month");
+
+  try {
+    const users = await prisma.user.findMany({
+      include: {
+        Duty: {
+          include: { Shif: true },
+          where: {
+            AND: { datetime: { gte: firstDay.format() } },
+            datetime: { lte: lastDay.format() },
+          },
+        },
+        OnCallDuty: {
+          where: {
+            AND: { datetime: { gte: firstDay.format() } },
+            datetime: { lte: lastDay.format() },
+          },
+        },
+        UserDuty: {
+          where: {
+            AND: {
+              datetime: { gte: firstDay.format() },
+              locationId: { not: null },
+            },
+          },
+        },
+        Position: true,
+        Title: true,
+      },
+      where: {
+        isPartTime: false,
+        UserDuty: {
+          some: {
+            AND: {
+              datetime: { gte: firstDay.format() },
+              locationId: { not: null },
+            },
+          },
+        },
+      },
+    });
+
+    const isOT = (d) => !!(d.isOT || d.Shif?.isOT);
+
+    const result = users
+      .map((u) => {
+        const reg = (name) =>
+          u.Duty.filter((d) => d.Shif?.name === name && !isOT(d)).length;
+        const otOf = (name) =>
+          u.Duty.filter((d) => d.Shif?.name === name && isOT(d)).length;
+
+        const morning = reg("ช");
+        const afternoon = reg("บ");
+        const night = reg("ด");
+        const otTotal = u.Duty.filter((d) => isOT(d)).length;
+        const dayOff = u.Duty.filter((d) => ["x", "R"].includes(d.Shif?.name)).length;
+        const onCall = u.OnCallDuty.length;
+        const workShifts = morning + afternoon + night;
+        const weekendShifts = u.Duty.filter(
+          (d) =>
+            ["ช", "บ", "ด"].includes(d.Shif?.name) &&
+            [0, 6].includes(dayjs(d.datetime).day())
+        ).length;
+
+        // คะแนนภาระงาน: ถ่วงน้ำหนักตามความหนักของกะ + โบนัสเวรควบ
+        const byDate = {};
+        u.Duty.forEach((d) => {
+          if (!["ช", "บ", "ด"].includes(d.Shif?.name)) return;
+          const date = dayjs(d.datetime).format("YYYY-MM-DD");
+          (byDate[date] = byDate[date] || []).push(d.Shif.name);
+        });
+        let dutyDays = 0;
+        let doubleShiftDays = 0;
+        let workloadScore = 0;
+        Object.values(byDate).forEach((names) => {
+          dutyDays++;
+          const base = names.reduce((a, n) => a + (SHIFT_WEIGHT[n] || 1), 0);
+          // โบนัสเฉพาะเวรควบเช้า-บ่าย (ทำต่อเนื่อง 16 ชม.)
+          const isMorningAfternoon = names.includes("ช") && names.includes("บ");
+          if (isMorningAfternoon) doubleShiftDays++;
+          workloadScore += base + (isMorningAfternoon ? DOUBLE_SHIFT_BONUS : 0);
+        });
+        workloadScore = Math.round(workloadScore * 10) / 10;
+
+        return {
+          id: u.id,
+          firstname: u.firstname,
+          lastname: u.lastname,
+          title: u.Title?.name || "",
+          position: u.Position?.name || "",
+          morning,
+          afternoon,
+          night,
+          otMorning: otOf("ช"),
+          otAfternoon: otOf("บ"),
+          otNight: otOf("ด"),
+          ot: otTotal,
+          dayOff,
+          onCall,
+          weekendShifts,
+          workShifts,
+          totalShifts: workShifts + otTotal,
+          dutyDays,
+          doubleShiftDays,
+          workloadScore,
+        };
+      })
+      .filter((u) => u.firstname)
+      .sort((a, b) => b.workloadScore - a.workloadScore);
+
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(400).json({ success: false, error: error.message });
+  }
+}

--- a/pages/api/staff-assignment/index.js
+++ b/pages/api/staff-assignment/index.js
@@ -149,6 +149,13 @@ async function autoAssignStaff(locationId, month, year) {
 
     for (const assignment of assignments) {
       try {
+        // กันการสร้างซ้ำ: ลบ UserDuty เดิมของพนักงานคนนี้ในเดือนนี้ก่อน
+        await prisma.userDuty.deleteMany({
+          where: {
+            userId: assignment.userId,
+            datetime: { gte: startDate.toDate(), lte: endDate.toDate() }
+          }
+        });
         let currentDate = startDate;
         while (currentDate.isBefore(endDate) || currentDate.isSame(endDate, "day")) {
           await prisma.userDuty.create({
@@ -200,6 +207,13 @@ async function manualAssignStaff(assignments, month, year) {
       }
 
       try {
+        // กันการสร้างซ้ำ: ลบ UserDuty เดิมของพนักงานคนนี้ในเดือนนี้ก่อน
+        await prisma.userDuty.deleteMany({
+          where: {
+            userId: assignment.userId,
+            datetime: { gte: startDate.toDate(), lte: endDate.toDate() }
+          }
+        });
         // สร้าง UserDuty record สำหรับทุกวันในเดือน
         let currentDate = startDate;
         while (currentDate.isBefore(endDate) || currentDate.isSame(endDate, "day")) {

--- a/pages/fairness.jsx
+++ b/pages/fairness.jsx
@@ -1,0 +1,20 @@
+import DropDownDate from "@/components/DropDownDate/DropDownDate";
+import FairnessDashboard from "@/components/Fairness/FairnessDashboard";
+import { useSelector } from "react-redux";
+
+export default function FairnessPage() {
+  const { dateStore } = useSelector((state) => ({ ...state }));
+  const month = dateStore.value.month;
+  const year = dateStore.value.year;
+
+  return (
+    <div className="py-8 min-h-screen bg-gray-50">
+      <div className="px-4 mx-auto max-w-6xl">
+        <div className="mb-6 text-center">
+          <DropDownDate />
+        </div>
+        <FairnessDashboard month={month} year={year} />
+      </div>
+    </div>
+  );
+}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,5 +1,7 @@
 import TableIndex from "@/components/TableIndex/TableIndex";
 import MonthYearSelector from "@/components/MonthYearSelector/MonthYearSelector";
+import FairnessSummaryCard from "@/components/Fairness/FairnessSummaryCard";
+import TodayBoard from "@/components/Home/TodayBoard";
 import dayjs from "dayjs";
 import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
@@ -40,6 +42,16 @@ export default function Home() {
           selectedYear={selectedYear}
           onMonthYearChange={handleMonthYearChange}
         />
+      </div>
+
+      {/* เวรของฉัน + เข้าเวรวันนี้ */}
+      <div className="max-w-6xl mx-auto px-4 mb-6">
+        <TodayBoard month={selectedMonth} year={selectedYear} />
+      </div>
+
+      {/* การ์ดสรุปความเป็นธรรมแบบย่อ */}
+      <div className="max-w-4xl mx-auto px-4 mb-6">
+        <FairnessSummaryCard month={selectedMonth} year={selectedYear} />
       </div>
 
       <TableIndex month={selectedMonth} year={selectedYear} />

--- a/pages/official-schedule.jsx
+++ b/pages/official-schedule.jsx
@@ -5,6 +5,7 @@ import "dayjs/locale/th";
 import Layout from "@/components/Layout/Layout";
 import OfficialScheduleTable from "@/components/OfficialScheduleTable/OfficialScheduleTable";
 import MonthYearSelector from "@/components/MonthYearSelector/MonthYearSelector";
+import ExportExcelButton from "@/components/ExportExcelButton";
 import { authProvider } from "src/authProvider";
 
 dayjs.locale("th");
@@ -77,18 +78,7 @@ export default function OfficialSchedule() {
             🖨️ พิมพ์ตาราง
           </button>
           
-          <button
-            onClick={() => {
-              const table = document.querySelector('table');
-              if (table) {
-                const csvContent = generateCSV(table);
-                downloadCSV(csvContent, `schedule-${monthTH}-${yearTH}.csv`);
-              }
-            }}
-            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          >
-            📄 ส่งออก CSV
-          </button>
+          <ExportExcelButton month={selectedMonth} year={selectedYear} />
         </div>
 
         {/* ตารางทางการ */}
@@ -111,35 +101,3 @@ export default function OfficialSchedule() {
   );
 }
 
-// ฟังก์ชันสำหรับสร้าง CSV
-function generateCSV(table) {
-  const rows = table.querySelectorAll('tr');
-  const csvData = [];
-  
-  rows.forEach(row => {
-    const cells = row.querySelectorAll('td, th');
-    const rowData = [];
-    cells.forEach(cell => {
-      rowData.push(cell.textContent.trim());
-    });
-    csvData.push(rowData.join(','));
-  });
-  
-  return csvData.join('\n');
-}
-
-// ฟังก์ชันสำหรับดาวน์โหลด CSV
-function downloadCSV(csvContent, filename) {
-  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-  const link = document.createElement('a');
-  
-  if (link.download !== undefined) {
-    const url = URL.createObjectURL(blob);
-    link.setAttribute('href', url);
-    link.setAttribute('download', filename);
-    link.style.visibility = 'hidden';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  }
-} 

--- a/pages/reservation.jsx
+++ b/pages/reservation.jsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import dayjs from "dayjs";
+import "dayjs/locale/th";
+import ReservationButton from "@/components/ShiftReservation/ReservationButton";
+
+dayjs.locale("th");
+
+const WEEKDAYS = ["อา", "จ", "อ", "พ", "พฤ", "ศ", "ส"];
+
+export default function ReservationPage() {
+  // ค่าเริ่มต้น = เดือนหน้า (จองเวรล่วงหน้า)
+  const [refDate, setRefDate] = useState(dayjs().add(1, "month").startOf("month"));
+  const [refresh, setRefresh] = useState(0);
+
+  const month = refDate.month();
+  const year = refDate.year();
+  const daysInMonth = refDate.daysInMonth();
+  const firstDayOfWeek = refDate.day(); // 0=อาทิตย์
+  const monthTH = refDate.format("MMMM");
+  const yearTH = year + 543;
+
+  const isWeekend = (day) => {
+    const dow = refDate.date(day).day();
+    return dow === 0 || dow === 6;
+  };
+
+  return (
+    <div className="py-8 min-h-screen bg-gray-50">
+      <div className="px-4 mx-auto max-w-3xl">
+        <h1 className="mb-1 text-2xl font-bold text-gray-900">จองเวร</h1>
+        <p className="mb-5 text-sm text-gray-600">
+          เลือกวันแล้วกดสัญลักษณ์ <span className="font-medium">🔖</span> เพื่อจองกะที่ต้องการ —
+          ระบบจัดตารางอัตโนมัติจะพยายามจัดตามที่จองไว้
+        </p>
+
+        {/* นำทางเดือน */}
+        <div className="flex justify-between items-center p-3 mb-3 bg-white rounded-xl border shadow-sm">
+          <button
+            onClick={() => setRefDate(refDate.subtract(1, "month"))}
+            className="px-3 py-1 text-gray-600 rounded-lg hover:bg-gray-100"
+          >
+            ‹ ก่อนหน้า
+          </button>
+          <div className="text-lg font-semibold text-gray-800">
+            {monthTH} {yearTH}
+          </div>
+          <button
+            onClick={() => setRefDate(refDate.add(1, "month"))}
+            className="px-3 py-1 text-gray-600 rounded-lg hover:bg-gray-100"
+          >
+            ถัดไป ›
+          </button>
+        </div>
+
+        {/* คำอธิบายสัญลักษณ์ */}
+        <div className="flex flex-wrap gap-4 px-1 mb-3 text-xs text-gray-600">
+          <span className="flex gap-1 items-center"><span className="text-gray-400">🔖</span> ยังไม่จอง</span>
+          <span className="flex gap-1 items-center"><span className="text-blue-600">🔖</span> ระบุความต้องการ</span>
+          <span className="flex gap-1 items-center"><span className="text-green-600">🔖</span> จองแน่นอน</span>
+        </div>
+
+        {/* ปฏิทิน */}
+        <div className="p-3 bg-white rounded-xl border shadow-sm">
+          <div className="grid grid-cols-7 gap-1 mb-1">
+            {WEEKDAYS.map((d, i) => (
+              <div key={d} className={`text-center text-xs font-medium py-1 ${i === 0 || i === 6 ? "text-red-500" : "text-gray-500"}`}>
+                {d}
+              </div>
+            ))}
+          </div>
+          <div className="grid grid-cols-7 gap-1">
+            {Array.from({ length: firstDayOfWeek }).map((_, i) => (
+              <div key={`empty-${i}`} />
+            ))}
+            {Array.from({ length: daysInMonth }, (_, i) => i + 1).map((day) => (
+              <div
+                key={day}
+                className={`flex flex-col items-center justify-between rounded-lg border p-1 min-h-[60px] ${
+                  isWeekend(day) ? "bg-red-50 border-red-100" : "bg-gray-50 border-gray-100"
+                }`}
+              >
+                <div className="text-sm font-medium text-gray-700">{day}</div>
+                <ReservationButton
+                  key={`${day}-${refresh}`}
+                  day={day}
+                  month={month}
+                  year={year}
+                  onReservationUpdate={() => setRefresh((r) => r + 1)}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,6 +417,11 @@ acorn@^8.8.0:
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
+adler-32@~1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/adler-32/-/adler-32-1.3.1.tgz#1dbf0b36dda0012189a32b3679061932df1821e2"
+  integrity sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==
+
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
@@ -656,6 +661,14 @@ caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001426, caniuse-lite@^1.0.300014
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001581.tgz"
   integrity sha512-whlTkwhqV2tUmP3oYhtNfaWGYHDdS3JYFQBKXxcUR9qqPWsRhFHhoISO2Xnl/g0xyKzht9mI1LZpiNWfMzHixQ==
 
+cfb@~1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/cfb/-/cfb-1.2.2.tgz#94e687628c700e5155436dac05f74e08df23bc44"
+  integrity sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==
+  dependencies:
+    adler-32 "~1.3.0"
+    crc-32 "~1.2.0"
+
 chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
@@ -702,6 +715,11 @@ clsx@^1.1.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
+codepage@~1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/codepage/-/codepage-1.15.0.tgz#2e00519024b39424ec66eeb3ec07227e692618ab"
+  integrity sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -754,6 +772,11 @@ cosmiconfig@^7.0.1:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
+
+crc-32@~1.2.0, crc-32@~1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.2.tgz#3cad35a934b8bf71f25ca524b6da51fb7eace2ff"
+  integrity sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==
 
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
@@ -1355,6 +1378,11 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+frac@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/frac/-/frac-1.1.2.tgz#3d74f7f6478c88a1b5020306d747dc6313c74d0b"
+  integrity sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==
 
 fraction.js@^4.2.0:
   version "4.2.0"
@@ -2714,6 +2742,13 @@ split2@^4.0.0:
   resolved "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz"
   integrity sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==
 
+ssf@~0.11.2:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/ssf/-/ssf-0.11.2.tgz#0b99698b237548d088fc43cdf2b70c1a7512c06c"
+  integrity sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==
+  dependencies:
+    frac "~1.1.2"
+
 stop-iteration-iterator@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz"
@@ -3019,15 +3054,38 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
+wmf@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wmf/-/wmf-1.0.2.tgz#7d19d621071a08c2bdc6b7e688a9c435298cc2da"
+  integrity sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==
+
 word-wrap@^1.2.3:
   version "1.2.3"
   resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
+word@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/word/-/word-0.3.0.tgz#8542157e4f8e849f4a363a288992d47612db9961"
+  integrity sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+xlsx@^0.18.5:
+  version "0.18.5"
+  resolved "https://registry.yarnpkg.com/xlsx/-/xlsx-0.18.5.tgz#16711b9113c848076b8a177022799ad356eba7d0"
+  integrity sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==
+  dependencies:
+    adler-32 "~1.3.0"
+    cfb "~1.2.1"
+    codepage "~1.15.0"
+    crc-32 "~1.2.1"
+    ssf "~0.11.2"
+    wmf "~1.0.1"
+    word "~0.3.0"
 
 xtend@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
## สรุป
ปรับปรุงระบบจัดเวรหลายส่วน ต่อยอดจากการแก้เรียงกะวันเดียวกัน (merged แล้วใน #2)

## สิ่งที่เปลี่ยน

### 1. ซ่อม + ปรับ auto-schedule ให้จัดเวรตามรูปแบบเวรจริง
วิเคราะห์ Duty จริงของ ICU ย้อนหลังมาตั้งเป็นกฎ:
- จัดเวร OT เช้า (~2 คน/วัน) + เวรควบ `ช(OT)+บ`, `ด+บ(OT)` ตามที่พบจริง (เดิมจัดได้แต่ off)
- ซ่อมบั๊ก: `resolveConflicts` ลบเวรที่เพิ่งจัดทิ้ง, `isOnCall` ทำ apply พัง (Prisma throw), data-shape API↔frontend ไม่ตรง (preview ว่าง/บันทึกไม่ได้), สร้าง UserDuty ซ้ำ, จัดแค่ 28 วันแทนทั้งเดือน, กะ OT แสดง "ไม่ทราบ"

### 2. หน้าสรุปความเป็นธรรม (Fairness Dashboard)
- คะแนนภาระงานถ่วงน้ำหนัก: เช้า×1.0, บ่าย×1.2, ดึก×1.5, ควบเช้า-บ่าย +0.5 (สะท้อนความอดนอน)
- ตาราง + กราฟ + ไฮไลต์คนภาระมาก/น้อย + การ์ดสรุปย่อที่หน้า Home

### 3. ปรับหน้า Home
- การ์ด "เวรของฉัน / เพื่อนร่วมงานวันนี้ / เข้าเวรวันนี้" + สรุปเดือนส่วนตัว (responsive มือถือ)
- ไฮไลต์คอลัมน์วันปัจจุบันในตาราง

### 4. หน้าจองเวร
- ปฏิทินจองเวรล่วงหน้า (เลือกกะ/ความสำคัญ/จองแน่นอน/วันหยุด) เชื่อม `shift-preference` ที่ auto-schedule อ่านอยู่แล้ว

### 5. Export Excel
- ปุ่มส่งออกตารางเวรเป็น `.xlsx` จริง (SheetJS) ดึงข้อมูลจาก DB โดยตรง รองรับภาษาไทย

## หมายเหตุสำหรับ reviewer
- การจอง "หยุด (OFF)" เพิ่มในตัวเลือกแล้ว แต่ auto-schedule ยังไม่ได้กันเวรให้คนที่ขอหยุด (ใช้ reservationMap แค่ boost ลำดับ) — เป็นงานต่อยอด
- ยังเหลือ INSUFFICIENT_STAFF บางวัน เพราะ ICU มี 8 คนกับ requirement ที่ตึง (ปรับได้ที่ SHIFT_REQUIREMENTS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)