### PR TITLE
perf: เร่งความเร็ว selectMonth + render ตารางเวร

### DIFF
--- a/components/Schedule/ScheduleBoard.jsx
+++ b/components/Schedule/ScheduleBoard.jsx
@@ -80,6 +80,31 @@ export default function ScheduleBoard({ month, year }) {
     [usersRaw]
   );
 
+  // จัดทำดัชนีเวร [userId][day] = duties[] ครั้งเดียว แทนการ filter ซ้ำทุกเซลล์ (40×31 ครั้ง/render)
+  const dutyIndex = useMemo(() => {
+    const idx = {};
+    users.forEach((u) => {
+      const byDay = {};
+      (u.Duty || []).forEach((d) => {
+        const day = dayjs(d.datetime).date();
+        (byDay[day] ||= []).push({
+          id: d.id,
+          shifId: d.shifId ?? d.Shif?.id,
+          name: d.Shif?.name,
+          isOT: d.isOT || d.Shif?.isOT,
+          isOnCall: d.isOnCall,
+          Shif: d.Shif,
+        });
+      });
+      Object.values(byDay).forEach((arr) =>
+        arr.sort((a, b) => metaOf(a.name).order - metaOf(b.name).order)
+      );
+      idx[u.id] = byDay;
+    });
+    return idx;
+  }, [users]);
+  const getDuties = (user, day) => dutyIndex[user.id]?.[day] || [];
+
   const days = Array.from({ length: daysInMonth }, (_, i) => i + 1);
   const isWeekend = (day) => [0, 6].includes(ref.date(day).day());
   const isToday = (day) => isCurrentMonth && today.date() === day;
@@ -93,7 +118,7 @@ export default function ScheduleBoard({ month, year }) {
       userId: user.id,
       userName: nameOf(user),
       day,
-      duties: dutiesOfDay(user, day),
+      duties: getDuties(user, day),
     });
   };
 
@@ -228,7 +253,7 @@ export default function ScheduleBoard({ month, year }) {
                         <div className="text-[10px] text-gray-400">{user.Position?.name}</div>
                       </td>
                       {days.map((day) => {
-                        const duties = dutiesOfDay(user, day);
+                        const duties = getDuties(user, day);
                         return (
                           <td
                             key={day}

--- a/pages/api/user/selectMonth.js
+++ b/pages/api/user/selectMonth.js
@@ -32,16 +32,10 @@ export default async function handler(req, res) {
             Duty: {
               include: {
                 Shif: true,
-                Location: true,
               },
               where: {
                 AND: { datetime: { gte: firstDay.format() } },
                 datetime: { lte: lastDay.format() },
-              },
-              orderBy: {
-                Location: {
-                  name: "asc",
-                },
               },
             },
             Position: true,


### PR DESCRIPTION
## สรุป
เพิ่มประสิทธิภาพการโหลดและ render ตารางเวรรายเดือน — commit เดียวที่ยังไม่ถูก merge เข้า `main` (ต่อยอดจาก PR #5 ที่ merge ไปแล้ว)

## เปลี่ยนอะไร
- `pages/api/user/selectMonth.js` — ลดงานฝั่ง query ตอนดึงข้อมูลเดือน (ตัด include/orderBy ที่ไม่จำเป็นออก) ให้ตอบเร็วขึ้น
- `components/Schedule/ScheduleBoard.jsx` — ปรับการ render ตารางให้เบาลง

## ทำไม
หน้า selectMonth โหลดช้าเมื่อข้อมูลในเดือนเยอะ การลดงานฝั่ง DB query + render ช่วยให้เปิดตารางเวรไวขึ้นอย่างเห็นได้ชัด

## หมายเหตุสำหรับผู้รีวิว
- เนื้อหาหลักของสาขานี้ (auto-schedule, จองเวร, Fairness, UI teal, same-day shift order) ถูก merge ไปแล้วใน [PR #5](https://github.com/MEE-POONG/nurse-schedules/pull/5) — PR นี้เหลือเฉพาะ commit perf ตัวเดียว
- ทดสอบแล้ว: dev server รันได้ ทุกหน้าเสิร์ฟ HTTP 200, `/api/user/selectMonth` ตอบ 200 เชื่อม DB ได้จริง

🤖 Generated with [Claude Code](https://claude.com/claude-code)