### PR TITLE
feat: PWA + Web Push แจ้งเตือนเวร (พร้อม cron เตือนก่อนเข้าเวร)

### DIFF
--- a/utils/pushNotify.js
+++ b/utils/pushNotify.js
@@ -151,7 +151,10 @@ export async function sendShiftReminders(prisma, { leadMinutes = 60 } = {}) {
   for (const { model, isOnCall } of sources) {
     const rows = await model.findMany({
       where: {
-        reminderSentAt: null,
+        // เวรเก่าถูกสร้างก่อนจะมี field นี้ → ใน Mongo field จะ "ไม่มี" (ไม่ใช่ null)
+        // Prisma { reminderSentAt: null } จะ match เฉพาะที่เป็น null จริง ไม่ครอบคลุม field ที่ไม่มี
+        // จึงต้อง OR กับ isSet:false ด้วย ไม่งั้นจะ scan ได้ 0 เสมอ
+        OR: [{ reminderSentAt: null }, { reminderSentAt: { isSet: false } }],
         datetime: { gte: rangeStart, lte: rangeEnd },
       },
       include: { Shif: true },


### PR DESCRIPTION
## ภาพรวม
เพิ่มความสามารถ PWA + Web Push notification ให้ระบบจัดเวร เพื่อแจ้งเตือนพยาบาลผ่านเบราว์เซอร์/มือถือ

## มีอะไรบ้าง
- **PWA**: ติดตั้งเป็นแอปได้ (manifest + service worker)
- **Web Push 4 กรณี**:
  - ได้รับมอบหมายเวร / แก้เวร
  - ได้รับมอบหมายเวร On-call (ICU)
  - เปิดตารางเดือนใหม่
  - ⏰ เตือนก่อนเข้าเวร (ส่งผ่าน cron)
- **Cron**: GitHub Actions เรียก `/api/push/cron/shift-reminders` เป็นระยะ เพื่อเตือนเวรที่จะเริ่มภายใน lead time

## บั๊กฟิกซ์ในแบรนช์นี้
ระหว่างทดสอบพบว่า cron เตือนก่อนเข้าเวรคืน `scanned: 0` ตลอด — ไม่ส่งแจ้งเตือนเลย

**สาเหตุ**: เวรเก่า (~7,400 รายการ) ถูกสร้างก่อนเพิ่ม field `reminderSentAt` ใน schema → เอกสารใน MongoDB **ไม่มี field นี้** (field หาย ≠ `null`) ซึ่ง Prisma `{ reminderSentAt: null }` จะ match เฉพาะค่าที่เป็น `null` จริง ไม่ครอบคลุม field ที่ไม่มี

**แก้**: กรองด้วย `OR: [{ reminderSentAt: null }, { reminderSentAt: { isSet: false } }]`

ตรวจกับ DB จริง: หลังแก้ scan เจอเวรในช่วง (จาก 0 → 12) เรียบร้อย

## สิ่งที่ผู้รีวิวควรทราบ
- ต้องตั้ง env `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT` (และ public key ฝั่ง client) ตอน deploy ไม่งั้น push จะถูกข้าม
- ถ้าตั้ง env `CRON_SECRET` ต้องส่ง header `x-cron-secret` ให้ตรงเวลาเรียก cron endpoint
- ความถี่ cron ควรสัมพันธ์กับ `lead` (ดีฟอลต์ 60 นาที) เพื่อไม่ให้พลาด/ส่งซ้ำ

🤖 Generated with [Claude Code](https://claude.com/claude-code)