### PR TITLE
fix: เรียงกะหน้าแรกเป็น ดึก→เช้า→บ่าย ให้ตรงลำดับเวลาจริง

### DIFF
--- a/components/Home/TodayBoard.jsx
+++ b/components/Home/TodayBoard.jsx
@@ -46,8 +46,11 @@ const TodayBoard = ({ month, year }) => {
   };
 
   // ---- เวร/สถิติของฉัน ----
+  const SHIFT_ORDER = { ด: 1, ช: 2, บ: 3 };
   const myData = me?.id ? users.find((u) => u.id === me.id) : null;
-  const myToday = refDay && myData ? dutiesOn(myData, refDay) : [];
+  const myToday = (refDay && myData ? dutiesOn(myData, refDay) : []).sort(
+    (a, b) => (SHIFT_ORDER[a.Shif?.name] ?? 99) - (SHIFT_ORDER[b.Shif?.name] ?? 99)
+  );
 
   const monthStat = (u) => {
     const reg = (name) => (u.Duty || []).filter((d) => d.Shif?.name === name && !(d.isOT || d.Shif?.isOT)).length;
@@ -125,7 +128,7 @@ const TodayBoard = ({ month, year }) => {
         </div>
         {refDay && todayGroups && (
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-            {["ช", "บ", "ด"].map((s) => {
+            {["ด", "ช", "บ"].map((s) => {
               const info = SHIFT_INFO[s];
               const list = todayGroups[s];
               return (

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "20.x"
+    "node": ">=20"
   },
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "tarangwen",
   "version": "1.0.0",
   "private": true,
+  "engines": {
+    "node": "20.x"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## สิ่งที่แก้

การ์ดหน้าแรก (TodayBoard) เดิมเรียงกะเป็น เช้า → บ่าย → ดึก ซึ่งไม่ตรงลำดับเวลาจริงของวัน (เวรดึกเริ่ม 00:30 เป็นกะแรกของวัน)

- **การ์ดเข้าเวรวันนี้**: เรียงคอลัมน์ใหม่เป็น ดึก → เช้า → บ่าย
- **การ์ดเวรของฉัน**: เรียงชิพเวร (และรายชื่อเพื่อนร่วมกะ) ตามลำดับเดียวกัน สำหรับวันที่ควบเวรหลายกะ

## หมายเหตุสำหรับผู้รีวิว

ลำดับนี้ตรงกับที่ใช้อยู่แล้วใน `ModalSelectMonth*` (`SHIFT_ORDER = { ด: 1, ช: 2, บ: 3 }`) และ `ScheduleCalendar` — เป็นการทำให้หน้าแรกสอดคล้องกับส่วนอื่นของระบบ ไม่กระทบข้อมูลหรือ API

🤖 Generated with [Claude Code](https://claude.com/claude-code)