### PR TITLE
fix: กรอง UserDuty ด้วยขอบบนของเดือนใน selectMonth ทุก endpoint

### DIFF
--- a/pages/api/user/select-month-on-call.js
+++ b/pages/api/user/select-month-on-call.js
@@ -22,7 +22,7 @@ export default async function handler(req, res) {
               },
               where: {
                 AND: {
-                  datetime: { gte: firstDay.format() },
+                  datetime: { gte: firstDay.format(), lte: lastDay.format() },
                   locationId: {
                     not: null,
                   },
@@ -51,7 +51,7 @@ export default async function handler(req, res) {
             UserDuty: {
               some: {
                 AND: {
-                  datetime: { gte: firstDay.format() },
+                  datetime: { gte: firstDay.format(), lte: lastDay.format() },
                   locationId: {
                     not: null,
                   },

--- a/pages/api/user/selectMonth.js
+++ b/pages/api/user/selectMonth.js
@@ -22,7 +22,7 @@ export default async function handler(req, res) {
               },
               where: {
                 AND: {
-                  datetime: { gte: firstDay.format() },
+                  datetime: { gte: firstDay.format(), lte: lastDay.format() },
                   locationId: {
                     not: null,
                   },
@@ -45,7 +45,7 @@ export default async function handler(req, res) {
             UserDuty: {
               some: {
                 AND: {
-                  datetime: { gte: firstDay.format() },
+                  datetime: { gte: firstDay.format(), lte: lastDay.format() },
                   locationId: {
                     not: null,
                   },

--- a/pages/api/user/selectMonthAF.js
+++ b/pages/api/user/selectMonthAF.js
@@ -22,7 +22,7 @@ export default async function handler(req, res) {
               },
               where: {
                 AND: {
-                  datetime: { gte: firstDay.format() },
+                  datetime: { gte: firstDay.format(), lte: lastDay.format() },
                   locationId: {
                     not: null,
                   },
@@ -52,7 +52,7 @@ export default async function handler(req, res) {
             UserDuty: {
               some: {
                 AND: {
-                  datetime: { gte: firstDay.format() },
+                  datetime: { gte: firstDay.format(), lte: lastDay.format() },
                   locationId: {
                     not: null,
                   },

--- a/pages/api/user/selectMonthNoR.js
+++ b/pages/api/user/selectMonthNoR.js
@@ -22,7 +22,7 @@ export default async function handler(req, res) {
               },
               where: {
                 AND: {
-                  datetime: { gte: firstDay.format() },
+                  datetime: { gte: firstDay.format(), lte: lastDay.format() },
                   locationId: {
                     not: null,
                   },
@@ -52,7 +52,7 @@ export default async function handler(req, res) {
             UserDuty: {
               some: {
                 AND: {
-                  datetime: { gte: firstDay.format() },
+                  datetime: { gte: firstDay.format(), lte: lastDay.format() },
                   locationId: {
                     not: null,
                   },

--- a/pages/api/user/selectMonthOT.js
+++ b/pages/api/user/selectMonthOT.js
@@ -22,7 +22,7 @@ export default async function handler(req, res) {
               },
               where: {
                 AND: {
-                  datetime: { gte: firstDay.format() },
+                  datetime: { gte: firstDay.format(), lte: lastDay.format() },
                   locationId: {
                     not: null,
                   },
@@ -52,7 +52,7 @@ export default async function handler(req, res) {
             UserDuty: {
               some: {
                 AND: {
-                  datetime: { gte: firstDay.format() },
+                  datetime: { gte: firstDay.format(), lte: lastDay.format() },
                   locationId: {
                     not: null,
                   },

--- a/pages/api/user/selectMonthR.js
+++ b/pages/api/user/selectMonthR.js
@@ -22,7 +22,7 @@ export default async function handler(req, res) {
               },
               where: {
                 AND: {
-                  datetime: { gte: firstDay.format() },
+                  datetime: { gte: firstDay.format(), lte: lastDay.format() },
                   locationId: {
                     not: null,
                   },
@@ -52,7 +52,7 @@ export default async function handler(req, res) {
             UserDuty: {
               some: {
                 AND: {
-                  datetime: { gte: firstDay.format() },
+                  datetime: { gte: firstDay.format(), lte: lastDay.format() },
                   locationId: {
                     not: null,
                   },


### PR DESCRIPTION
## ปัญหา
คิวรีรายชื่อคนขึ้นเวรรายเดือน (`/api/user/selectMonth*` ทั้ง 6 endpoint) กรอง UserDuty ด้วย `datetime >= firstDay` เท่านั้น ไม่มีขอบบน ทำให้:
- คนที่ถูกจัดขึ้นเวร**เดือนถัดไป** โผล่ในตารางเดือนก่อนหน้าด้วย
- ถอดคนออกจากเดือนแล้ว (PR #20) ชื่ออาจยังค้างถ้ามี UserDuty เดือนอนาคต

## การแก้
เพิ่ม `lte: lastDay.format()` ในเงื่อนไข UserDuty ทั้ง 2 จุดต่อไฟล์ (include และ where.some) — 6 ไฟล์ 12 จุด:
selectMonth.js, selectMonthAF.js, selectMonthNoR.js, selectMonthOT.js, selectMonthR.js, select-month-on-call.js

ไม่แตะเงื่อนไขของ Duty ที่มีขอบบนถูกต้องอยู่แล้ว

## การทดสอบ
- `next lint` ผ่านทุกไฟล์
- diff เป็น mechanical change แบบเดียวกันทุกจุด

🤖 Generated with [Claude Code](https://claude.com/claude-code)