### PR TITLE
fix: จัดลายเซ็นท้ายใบตารางเวรให้ตรงกลางเส้นประ ไม่เบี้ยว

### DIFF
--- a/components/OnCall/TableSelectMonth/TableSelectMonthOnCall.jsx
+++ b/components/OnCall/TableSelectMonth/TableSelectMonthOnCall.jsx
@@ -9,7 +9,7 @@ import ModalSelectMonthOnCall from "./ModalSelectMonthOnCall";
 import { useSelector } from "react-redux";
 import LoadingComponent from "@/components/LoadingComponent";
 import ErrorComponent from "@/components/ErrorComponent";
-import SIGNATORIES from "@/utils/signatories";
+import ScheduleSignature from "@/components/TableSelectMonth/ScheduleSignature";
 var isoWeek = require("dayjs/plugin/isoWeek");
 dayjs.extend(isoWeek);
 export const TableSelectMonthOnCall = ({
@@ -399,40 +399,10 @@ export const TableSelectMonthOnCall = ({
                 </td>
               </tr>
 
-              <tr className="border" onClick={() => setOpen(e => e += 1)}>
-                <td
-                  className="py-5 border border-white"
-                  colSpan={daysInMonth + 9}
-                >
-
-                  <div className="hidden justify-between w-full sm:flex">
-                    <div>
-                      <p className="mt-3 text-center">ลงชื่อ......................................................................(ผู้อนุมัติอยู่เวร)</p>
-                      <p className="pl-32 text-left">
-                        ( {SIGNATORIES.director.name} )
-                        </p>
-                      <p className="pl-14 text-left">
-                        {SIGNATORIES.director.position}
-                        </p>
-                      <p className="text-leftpl-20">
-                        {SIGNATORIES.director.role}
-                        </p>
-                    </div>
-                    <div className="basis-6/12">
-                      <p className="mt-3 text-center">ลงชื่อ......................................................................(ผู้ควบคุม)</p>
-                      <p className="text-left pl-[20rem]">( {SIGNATORIES.nursingHead.name} )</p>
-                      <p className="text-left pl-[22rem]"></p>
-                      <p className="text-left pl-[19rem]">{SIGNATORIES.nursingHead.role}</p>
-                    </div>
-                    <div className="text-center">
-                      {/* <p className="mt-3 text-center">ความคิดเห็นผู้อำนวยการ</p> */}
-                      <p className="mt-3 text-center">ลงชื่อ......................................................หัวหน้าหน่วยงาน</p>
-                      <p className="pl-16 text-left">( {configuration?.departmentor} )</p>
-                    </div>
-                  </div>
-
-                </td>
-              </tr>
+              <ScheduleSignature
+                colSpan={daysInMonth + 9}
+                departmentor={configuration?.departmentor}
+              />
             </tbody>
           </table>
         </div>

--- a/components/TableSelectMonth/PaymentSignature.jsx
+++ b/components/TableSelectMonth/PaymentSignature.jsx
@@ -1,36 +1,30 @@
 import SIGNATORIES from "@/utils/signatories";
-
-const DOTS = ".".repeat(70);
+import { SignatureColumn, SignatureRow } from "./SignatureRow";
 
 // ลายเซ็นท้าย "ใบหลักฐานการจ่ายเงินค่าตอบแทน" (ใบรับเงิน)
 // การเงินแจ้งให้เรียงชื่อ ผอ. (ผู้อนุมัติ) ขึ้นก่อน แล้วตามด้วยผู้ควบคุมและผู้จ่ายเงิน
 // ใช้ร่วมกันทั้ง 3 ใบ (AF / OT / R) เพื่อให้แก้ชื่อ-ตำแหน่งที่เดียวแล้วตรงกันทุกใบ
-const SIGNATURE_BLOCKS = [
-  { label: "(ผู้อนุมัติ)", signer: SIGNATORIES.director },
-  { label: "(ผู้ควบคุม)", signer: SIGNATORIES.nursingHead },
-  { label: "ผู้จ่ายเงิน", signer: SIGNATORIES.finance },
-];
-
 export const PaymentSignature = ({ colSpan }) => (
-  <tr className="border">
-    <td className="py-5 border border-white" colSpan={colSpan}>
-      <div className="flex flex-row justify-center">
-        ขอรับรองว่าผู้ที่รับเงินค่าตอบแทนดังกล่าวได้ปฏิบัติงานนอกเวลาจริง
-      </div>
-      <div className="hidden justify-between w-full sm:flex">
-        {SIGNATURE_BLOCKS.map(({ label, signer }) => (
-          <div key={label} className="flex-1 px-2">
-            <p className="mt-3 text-center whitespace-nowrap">
-              ลงชื่อ{DOTS}{label}
-            </p>
-            <p className="text-center">( {signer.name} )</p>
-            <p className="text-center">{signer.position}</p>
-            {signer.role ? <p className="text-center">{signer.role}</p> : null}
-          </div>
-        ))}
-      </div>
-    </td>
-  </tr>
+  <SignatureRow
+    colSpan={colSpan}
+    note="ขอรับรองว่าผู้ที่รับเงินค่าตอบแทนดังกล่าวได้ปฏิบัติงานนอกเวลาจริง"
+  >
+    <SignatureColumn
+      label="(ผู้อนุมัติ)"
+      name={SIGNATORIES.director.name}
+      lines={[SIGNATORIES.director.position, SIGNATORIES.director.role]}
+    />
+    <SignatureColumn
+      label="(ผู้ควบคุม)"
+      name={SIGNATORIES.nursingHead.name}
+      lines={[SIGNATORIES.nursingHead.position, SIGNATORIES.nursingHead.role]}
+    />
+    <SignatureColumn
+      label="ผู้จ่ายเงิน"
+      name={SIGNATORIES.finance.name}
+      lines={[SIGNATORIES.finance.position]}
+    />
+  </SignatureRow>
 );
 
 export default PaymentSignature;

--- a/components/TableSelectMonth/ScheduleSignature.jsx
+++ b/components/TableSelectMonth/ScheduleSignature.jsx
@@ -1,0 +1,26 @@
+import SIGNATORIES from "@/utils/signatories";
+import { SignatureColumn, SignatureRow } from "./SignatureRow";
+
+// ลายเซ็นท้ายใบตารางเวร (ใบที่ไม่มีตัวเงิน)
+// ลำดับเดิม: ผู้อนุมัติอยู่เวร (ผอ.) → ผู้ควบคุม → หัวหน้าหน่วยงาน
+export const ScheduleSignature = ({ colSpan, departmentor, onClick }) => (
+  <SignatureRow colSpan={colSpan} onClick={onClick}>
+    <SignatureColumn
+      label="(ผู้อนุมัติอยู่เวร)"
+      name={SIGNATORIES.director.name}
+      lines={[SIGNATORIES.director.position, SIGNATORIES.director.role]}
+    />
+    <SignatureColumn
+      label="(ผู้ควบคุม)"
+      name={SIGNATORIES.nursingHead.name}
+      lines={[SIGNATORIES.nursingHead.role]}
+    />
+    <SignatureColumn
+      label="หัวหน้าหน่วยงาน"
+      dotCount={54}
+      name={departmentor}
+    />
+  </SignatureRow>
+);
+
+export default ScheduleSignature;

--- a/components/TableSelectMonth/SignatureRow.jsx
+++ b/components/TableSelectMonth/SignatureRow.jsx
@@ -1,0 +1,54 @@
+const dots = (count) => ".".repeat(count);
+
+// หนึ่งช่องลายเซ็น — ชื่อและตำแหน่งจัดกึ่งกลาง "เส้นประ" พอดี ไม่ใช่กึ่งกลางทั้งบรรทัด
+// (คำว่า ลงชื่อ กับวงเล็บท้ายบรรทัดยาวไม่เท่ากัน ถ้าจัดกลางทั้งบรรทัดชื่อจะเยื้องออกจากเส้น)
+// ของเดิมดันทีละบรรทัดด้วย pl-14 / pl-[20rem] ทำให้แต่ละบรรทัดเบี้ยวไม่ตรงกันเอง
+export const SignatureColumn = ({ label, dotCount = 70, name, lines = [] }) => {
+  const line = dots(dotCount);
+
+  return (
+    <div className="flex flex-1 justify-center px-2">
+      <div>
+        <p className="mt-3 whitespace-nowrap">
+          ลงชื่อ{line}{label}
+        </p>
+        <div className="flex">
+          {/* สองช่องนี้ล่องหน มีไว้กันที่ให้ตรงกับความกว้างของคำว่า ลงชื่อ และวงเล็บท้ายบรรทัด */}
+          <span className="invisible whitespace-nowrap" aria-hidden="true">
+            ลงชื่อ
+          </span>
+          <div>
+            <span
+              className="block invisible h-0 overflow-hidden whitespace-nowrap"
+              aria-hidden="true"
+            >
+              {line}
+            </span>
+            <p className="text-center">( {name} )</p>
+            {lines.filter(Boolean).map((text) => (
+              <p key={text} className="text-center">
+                {text}
+              </p>
+            ))}
+          </div>
+          <span className="invisible whitespace-nowrap" aria-hidden="true">
+            {label}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// แถวลายเซ็นท้ายตาราง ใช้ร่วมกันทุกใบ
+// onClick มีไว้สำหรับใบที่ใช้การคลิกแถวนี้เปิดส่วนแอดมินที่ซ่อนอยู่ (open >= 5)
+export const SignatureRow = ({ colSpan, note, onClick, children }) => (
+  <tr className="border" onClick={onClick}>
+    <td className="py-5 border border-white" colSpan={colSpan}>
+      {note ? <div className="flex flex-row justify-center">{note}</div> : null}
+      <div className="hidden justify-between w-full sm:flex">{children}</div>
+    </td>
+  </tr>
+);
+
+export default SignatureRow;

--- a/components/TableSelectMonth/TableSelectMonth.jsx
+++ b/components/TableSelectMonth/TableSelectMonth.jsx
@@ -12,7 +12,7 @@ import { useReactToPrint } from "react-to-print";
 import printStyle from "@/utils/printStyle";
 import { authProvider } from "src/authProvider";
 import { TableSelectMonthOnCall2 } from "../OnCall/TableSelectMonth/TableSelectMonthOnCall2";
-import SIGNATORIES from "@/utils/signatories";
+import ScheduleSignature from "./ScheduleSignature";
 var isoWeek = require("dayjs/plugin/isoWeek");
 dayjs.extend(isoWeek);
 export const TableSelectMonth = ({
@@ -784,50 +784,11 @@ export const TableSelectMonth = ({
                 </td>
               </tr>
 
-              <tr className="border" onClick={() => setOpen((e) => (e += 1))}>
-                <td
-                  className="py-5 border border-white"
-                  colSpan={daysInMonth + 9}
-                >
-                  <div className="hidden justify-between w-full sm:flex">
-                    <div>
-                      <p className="mt-3 text-center">
-                        ลงชื่อ......................................................................(ผู้อนุมัติอยู่เวร)
-                      </p>
-                      <p className="pl-32 text-left">
-                        ( {SIGNATORIES.director.name} )
-                      </p>
-                      <p className="pl-14 text-left">
-                        {SIGNATORIES.director.position}
-                      </p>
-                      <p className="text-leftpl-20">
-                        {SIGNATORIES.director.role}
-                      </p>
-                    </div>
-                    <div className="basis-6/12">
-                      <p className="mt-3 text-center">
-                        ลงชื่อ......................................................................(ผู้ควบคุม)
-                      </p>
-                      <p className="text-left pl-[20rem]">
-                        ( {SIGNATORIES.nursingHead.name} )
-                      </p>
-                      <p className="text-left pl-[22rem]"></p>
-                      <p className="text-left pl-[19rem]">
-                        {SIGNATORIES.nursingHead.role}
-                      </p>
-                    </div>
-                    <div className="text-center">
-                      {/* <p className="mt-3 text-center">ความคิดเห็นผู้อำนวยการ</p> */}
-                      <p className="mt-3 text-center">
-                        ลงชื่อ......................................................หัวหน้าหน่วยงาน
-                      </p>
-                      <p className="pl-16 text-left">
-                        ( {configuration?.departmentor} )
-                      </p>
-                    </div>
-                  </div>
-                </td>
-              </tr>
+              <ScheduleSignature
+                colSpan={daysInMonth + 9}
+                departmentor={configuration?.departmentor}
+                onClick={() => setOpen((e) => (e += 1))}
+              />
             </tbody>
           </table>
         </div>

--- a/components/TableSelectMonth/TableSelectMonthAFC.jsx
+++ b/components/TableSelectMonth/TableSelectMonthAFC.jsx
@@ -11,7 +11,7 @@ import { BsPrinterFill } from "react-icons/bs";
 import { useReactToPrint } from "react-to-print";
 import printStyle from "@/utils/printStyle";
 import ModalSelectMonthRed from "./ModalSelectMonthRed";
-import SIGNATORIES from "@/utils/signatories";
+import ScheduleSignature from "./ScheduleSignature";
 var isoWeek = require("dayjs/plugin/isoWeek");
 dayjs.extend(isoWeek);
 export const TableSelectMonthAFC = ({
@@ -330,40 +330,11 @@ export const TableSelectMonthAFC = ({
                 </td>
               </tr>
 
-              <tr className="border" onClick={() => setOpen(e => e += 1)}>
-                <td
-                  className="py-5 border border-white"
-                  colSpan={daysInMonth + 9}
-                >
-
-                  <div className="hidden justify-between w-full sm:flex">
-                    <div>
-                      <p className="mt-3 text-center">ลงชื่อ......................................................................(ผู้อนุมัติอยู่เวร)</p>
-                      <p className="pl-32 text-left">
-                        ( {SIGNATORIES.director.name} )
-                        </p>
-                      <p className="pl-14 text-left">
-                        {SIGNATORIES.director.position}
-                        </p>
-                      <p className="text-leftpl-20">
-                        {SIGNATORIES.director.role}
-                        </p>
-                    </div>
-                    <div className="basis-6/12">
-                      <p className="mt-3 text-center">ลงชื่อ......................................................................(ผู้ควบคุม)</p>
-                      <p className="text-left pl-[17rem]">( {SIGNATORIES.nursingHead.name} )</p>
-                      <p className="text-left pl-[22rem]"></p>
-                      <p className="text-left pl-[16rem]">{SIGNATORIES.nursingHead.role}</p>
-                    </div>
-                    <div className="text-center">
-                      {/* <p className="mt-3 text-center">ความคิดเห็นผู้อำนวยการ</p> */}
-                      <p className="mt-3 text-center">ลงชื่อ......................................................หัวหน้าหน่วยงาน</p>
-                      <p className="pl-16 text-left">( {configuration?.departmentor} )</p>
-                    </div>
-                  </div>
-
-                </td>
-              </tr>
+              <ScheduleSignature
+                colSpan={daysInMonth + 9}
+                departmentor={configuration?.departmentor}
+                onClick={() => setOpen((e) => (e += 1))}
+              />
 
             </tbody>
           </table>

--- a/components/TableSelectMonth/TableSelectMonthRF.jsx
+++ b/components/TableSelectMonth/TableSelectMonthRF.jsx
@@ -12,7 +12,7 @@ import { useReactToPrint } from "react-to-print";
 import printStyle from "@/utils/printStyle";
 import ModalSelectMonthRed from "./ModalSelectMonthRed";
 import ModalSelectMonthR from "./ModalSelectMonthR";
-import SIGNATORIES from "@/utils/signatories";
+import ScheduleSignature from "./ScheduleSignature";
 var isoWeek = require("dayjs/plugin/isoWeek");
 dayjs.extend(isoWeek);
 export const TableSelectMonthRF = ({
@@ -333,40 +333,11 @@ export const TableSelectMonthRF = ({
                 </td>
               </tr>
 
-              <tr className="border" onClick={() => setOpen(e => e += 1)}>
-                <td
-                  className="py-5 border border-white"
-                  colSpan={daysInMonth + 9}
-                >
-
-                  <div className="hidden justify-between w-full sm:flex">
-                    <div>
-                      <p className="mt-3 text-center">ลงชื่อ......................................................................(ผู้อนุมัติอยู่เวร)</p>
-                      <p className="pl-32 text-left">
-                        ( {SIGNATORIES.director.name} )
-                        </p>
-                      <p className="pl-14 text-left">
-                        {SIGNATORIES.director.position}
-                        </p>
-                      <p className="text-leftpl-20">
-                        {SIGNATORIES.director.role}
-                        </p>
-                    </div>
-                    <div className="basis-6/12">
-                      <p className="mt-3 text-center">ลงชื่อ......................................................................(ผู้ควบคุม)</p>
-                      <p className="text-left pl-[17rem]">( {SIGNATORIES.nursingHead.name} )</p>
-                      <p className="text-left pl-[22rem]"></p>
-                      <p className="text-left pl-[16rem]">{SIGNATORIES.nursingHead.role}</p>
-                    </div>
-                    <div className="text-center">
-                      {/* <p className="mt-3 text-center">ความคิดเห็นผู้อำนวยการ</p> */}
-                      <p className="mt-3 text-center">ลงชื่อ......................................................หัวหน้าหน่วยงาน</p>
-                      <p className="pl-16 text-left">( {configuration?.departmentor} )</p>
-                    </div>
-                  </div>
-
-                </td>
-              </tr>
+              <ScheduleSignature
+                colSpan={daysInMonth + 9}
+                departmentor={configuration?.departmentor}
+                onClick={() => setOpen((e) => (e += 1))}
+              />
 
             </tbody>
           </table>

--- a/components/TableSelectMonth/TableSelectMonthRed.jsx
+++ b/components/TableSelectMonth/TableSelectMonthRed.jsx
@@ -11,7 +11,7 @@ import { BsPrinterFill } from "react-icons/bs";
 import { useReactToPrint } from "react-to-print";
 import printStyle from "@/utils/printStyle";
 import ModalSelectMonthRed from "./ModalSelectMonthRed";
-import SIGNATORIES from "@/utils/signatories";
+import ScheduleSignature from "./ScheduleSignature";
 var isoWeek = require("dayjs/plugin/isoWeek");
 dayjs.extend(isoWeek);
 export const TableSelectMonthRed = ({
@@ -570,50 +570,11 @@ export const TableSelectMonthRed = ({
                 </td>
               </tr>
 
-              <tr className="border" onClick={() => setOpen((e) => (e += 1))}>
-                <td
-                  className="py-5 border border-white"
-                  colSpan={daysInMonth + 9}
-                >
-                  <div className="hidden justify-between w-full sm:flex">
-                    <div>
-                      <p className="mt-3 text-center">
-                        ลงชื่อ......................................................................(ผู้อนุมัติอยู่เวร)
-                      </p>
-                      <p className="pl-32 text-left">
-                        ( {SIGNATORIES.director.name} )
-                      </p>
-                      <p className="pl-14 text-left">
-                        {SIGNATORIES.director.position}
-                      </p>
-                      <p className="text-leftpl-20">
-                        {SIGNATORIES.director.role}
-                      </p>
-                    </div>
-                    <div className="basis-6/12">
-                      <p className="mt-3 text-center">
-                        ลงชื่อ......................................................................(ผู้ควบคุม)
-                      </p>
-                      <p className="text-left pl-[17rem]">
-                        ( {SIGNATORIES.nursingHead.name} )
-                      </p>
-                      <p className="text-left pl-[22rem]"></p>
-                      <p className="text-left pl-[16rem]">
-                        {SIGNATORIES.nursingHead.role}
-                      </p>
-                    </div>
-                    <div className="text-center">
-                      {/* <p className="mt-3 text-center">ความคิดเห็นผู้อำนวยการ</p> */}
-                      <p className="mt-3 text-center">
-                        ลงชื่อ......................................................หัวหน้าหน่วยงาน
-                      </p>
-                      <p className="pl-16 text-left">
-                        ( {configuration?.departmentor} )
-                      </p>
-                    </div>
-                  </div>
-                </td>
-              </tr>
+              <ScheduleSignature
+                colSpan={daysInMonth + 9}
+                departmentor={configuration?.departmentor}
+                onClick={() => setOpen((e) => (e += 1))}
+              />
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## ปัญหา

ท้ายใบตารางเวร ชื่อกับตำแหน่งใต้เส้นประเยื้องกันเอง ดูเบี้ยว

สาเหตุคือแต่ละบรรทัดถูกดันด้วย padding คนละค่าที่ไม่สัมพันธ์กัน — `pl-32` สำหรับชื่อ, `pl-14` สำหรับตำแหน่ง, `pl-[20rem]`/`pl-[19rem]` ในช่องผู้ควบคุม — เวลาข้อความยาวไม่เท่ากันก็ไม่มีทางตรงกัน

และบรรทัด "ผู้อำนวยการโรงพยาบาลครบุรี" ติด class ผิดเป็น `text-leftpl-20` (`text-left` กับ `pl-20` พิมพ์ติดกัน) กลายเป็น class ที่ไม่มีอยู่จริง บรรทัดนั้นจึงไม่มี padding เลย ชิดซ้ายสุดคนเดียว — ผิดเหมือนกันทั้ง 5 ใบ

## การแก้ไข

แยกลายเซ็นเป็นคอมโพเนนต์กลาง `SignatureRow` / `SignatureColumn` แล้วจัดชื่อและตำแหน่งให้อยู่กึ่งกลาง **เส้นประ** พอดี ไม่ใช่กึ่งกลางทั้งบรรทัด (คำว่า "ลงชื่อ" กับวงเล็บท้ายบรรทัดกว้างไม่เท่ากัน ถ้าจัดกลางทั้งบรรทัดชื่อจะเยื้องออกจากเส้นที่ต้องเซ็น) ทำโดยกันที่ด้วย span ล่องหนสองข้างให้ช่องกลางกว้างเท่าเส้นประเป๊ะ

| ไฟล์ | สิ่งที่เปลี่ยน |
|---|---|
| `SignatureRow.jsx` *(ใหม่)* | คอมโพเนนต์กลาง — แถวลายเซ็น + ช่องลายเซ็นที่จัดกึ่งกลางเส้นประ |
| `ScheduleSignature.jsx` *(ใหม่)* | ลายเซ็นท้ายใบตารางเวร (ผู้อนุมัติอยู่เวร → ผู้ควบคุม → หัวหน้าหน่วยงาน) |
| `TableSelectMonth.jsx`, `TableSelectMonthRed.jsx`, `TableSelectMonthAFC.jsx`, `TableSelectMonthRF.jsx`, `TableSelectMonthOnCall.jsx` | ใช้ `ScheduleSignature` แทนโค้ดลายเซ็นที่ก๊อปกันมา 5 ชุด |
| `PaymentSignature.jsx` | ใช้คอมโพเนนต์กลางชุดเดียวกัน |

**ลำดับผู้ลงนามและข้อความคงเดิมทุกอย่าง** เปลี่ยนเฉพาะตำแหน่งการวางให้ตรง ยกเว้นบรรทัดว่างเปล่าระหว่างชื่อกับตำแหน่งที่ตัดออก

หมายเหตุ: ใบตารางเวรยังไม่มีบรรทัด `พยาบาลวิชาชีพชำนาญการพิเศษ` ใต้ชื่อหัวหน้ากลุ่มงานการพยาบาล (มีเฉพาะใบหลักฐานการจ่ายเงินตามที่การเงินแจ้ง) ถ้าอยากให้มีทุกใบบอกได้ เพิ่มบรรทัดเดียว

## สิ่งที่ระวังไว้

การคลิกแถวลายเซ็น 5 ครั้งเพื่อเปิดส่วนแอดมินที่ซ่อนอยู่ (`open >= 5`) ยังใช้ได้เหมือนเดิมในใบที่ใช้จริง (Red / AFC / RF) — ส่งผ่าน prop `onClick` ส่วนใบ On-Call ไม่มี state `open` อยู่แล้ว `setOpen` จึงเป็น ReferenceError ตั้งแต่แรก ตัด `onClick` ทิ้ง

## การตรวจสอบ

- `npm run lint` — ผ่าน (เหลือ warning เดิมของ `PwaController.jsx`)
- `npm run build` — ผ่าน
- เรนเดอร์คอมโพเนนต์จริงในเบราว์เซอร์แล้ววัดระยะ: ทุกบรรทัดของทั้ง 6 ช่องลายเซ็น (ทั้งใบตารางเวรและใบหลักฐานการจ่ายเงิน) เยื้องจากกึ่งกลางเส้นประ **0.0 px**

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gaa6PVGhst2bnFkvwhmrj2)_